### PR TITLE
First attempt transforming directly to pixel values.

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
 
       #my-floating-inline {
         position: absolute;
-        top: anchor(--my-anchor-inline bottom);
-        left: anchor(--my-anchor-inline right);
+        top: anchor(--my-anchor-inline end);
+        left: anchor(--my-anchor-inline end);
         background: green;
       }
     </style>
@@ -46,20 +46,20 @@
 
     <h2>Anchor Positioning via anchor() (stylesheet)</h2>
     <div style="position: relative">
-      <div id="my-anchor-positioning">Anchor</div>
       <div id="my-floating-positioning">Floating</div>
+      <div id="my-anchor-positioning">Anchor</div>
     </div>
 
     <h2>Anchor Positioning via anchor() (inline)</h2>
     <div style="position: relative">
-      <div id="my-anchor-inline">Anchor</div>
       <div id="my-floating-inline">Floating</div>
+      <div id="my-anchor-inline">Anchor</div>
     </div>
 
     <h2>Anchor Positioning via position-fallback</h2>
     <div style="position: relative">
-      <div id="my-anchor-fallback">Anchor</div>
       <div id="my-floating-fallback">Floating</div>
+      <div id="my-anchor-fallback">Anchor</div>
     </div>
 
     <h2>Anchor Positioning (with scroll)</h2>

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -145,7 +145,7 @@ function parseAnchorFn(node: csstree.FunctionNode) {
         break;
       case 1:
         if (isIdentifier(child)) {
-          anchorEdge = child.name as AnchorSide;
+          anchorEdge = child.name as AnchorSideKeyword;
         } else if (isPercentage(child)) {
           const number = Number(child.value);
           anchorEdge = Number.isNaN(number) ? undefined : number;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -14,10 +14,23 @@ interface AnchorNames {
   [key: string]: string[];
 }
 
+export type AnchorSideKeyword =
+  | 'top'
+  | 'left'
+  | 'right'
+  | 'bottom'
+  | 'start'
+  | 'end'
+  | 'self-start'
+  | 'self-end'
+  | 'center';
+
+export type AnchorSide = AnchorSideKeyword | number;
+
 interface AnchorFunction {
   anchorEl?: string[];
   anchorName?: string;
-  anchorEdge?: string;
+  anchorEdge?: AnchorSide;
   fallbackValue: string;
 }
 
@@ -112,7 +125,7 @@ export function isPercentage(
 
 function parseAnchorFn(node: csstree.FunctionNode) {
   let anchorName: string | undefined,
-    anchorEdge: string | undefined,
+    anchorEdge: AnchorSide | undefined,
     fallbackValue = '',
     foundComma = false;
   node.children.toArray().forEach((child, idx) => {
@@ -132,9 +145,10 @@ function parseAnchorFn(node: csstree.FunctionNode) {
         break;
       case 1:
         if (isIdentifier(child)) {
-          anchorEdge = child.name;
+          anchorEdge = child.name as AnchorSide;
         } else if (isPercentage(child)) {
-          anchorEdge = `${child.value}%`;
+          const number = Number(child.value);
+          anchorEdge = Number.isNaN(number) ? undefined : number;
         }
         break;
     }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,16 +1,11 @@
-import {
-  autoUpdate,
-  Axis,
-  computePosition,
-  offset,
-  Placement,
-  Rect,
-} from '@floating-ui/dom';
+import { autoUpdate, computePosition, offset, Rect } from '@floating-ui/dom';
 import * as csstree from 'css-tree';
 
 import { fetchCSS, isStyleLink } from './fetch.js';
 import {
   AnchorPositions,
+  AnchorSide,
+  AnchorSideKeyword,
   getAST,
   isFallbackAtRule,
   isFallbackDeclaration,
@@ -70,24 +65,114 @@ export async function transformCSS() {
   // Or make `autoUpdate` work.
   setTimeout(() => {
     position(rules);
-  }, 1000);
+  }, 1500);
 }
 
-const getPixelValue = (
-  anchor: Rect,
-  edge: string | undefined,
-  fallback: string,
-) => {
+const resolveLogicalKeyword = (edge: AnchorSide, isRTL: boolean) => {
+  let percentage: number | undefined;
   switch (edge) {
-    case 'left':
-      return `${anchor.x}px`;
-    case 'right':
-      return `${anchor.x + anchor.width}px`;
-    case 'top':
-      return `${anchor.y}px`;
-    case 'bottom':
-      return `${anchor.y + anchor.height}px`;
+    case 'start':
+    case 'self-start':
+      percentage = 0;
+      break;
+    case 'end':
+    case 'self-end':
+      percentage = 100;
+      break;
+    default:
+      if (typeof edge === 'number' && !Number.isNaN(edge)) {
+        percentage = edge;
+      }
   }
+  if (percentage !== undefined) {
+    return isRTL ? 100 - percentage : percentage;
+  }
+  return undefined;
+};
+
+const getAxis = (position?: string) => {
+  switch (position) {
+    case 'top':
+    case 'bottom':
+      return 'y';
+    case 'left':
+    case 'right':
+      return 'x';
+  }
+  return null;
+};
+
+const getAxisProperty = (axis: 'x' | 'y' | null) => {
+  switch (axis) {
+    case 'x':
+      return 'width';
+    case 'y':
+      return 'height';
+  }
+  return null;
+};
+
+const getPixelValue = ({
+  floatingEl,
+  anchorRect,
+  anchorEdge,
+  floatingPosition,
+  fallback,
+}: {
+  floatingEl: HTMLElement;
+  anchorRect: Rect;
+  anchorEdge?: AnchorSide;
+  floatingPosition?: string;
+  fallback: string;
+}) => {
+  let percentage: number | undefined;
+  // This is required when the anchor edge is a logical keyword
+  // (`start/end/self-start/self-end/center`) or a percentage,
+  // not a physical keyword (`top/bottom/left/right`)
+  let axis: 'x' | 'y' | null = getAxis(floatingPosition);
+
+  switch (anchorEdge) {
+    case 'left':
+      percentage = 0;
+      axis = 'x';
+      break;
+    case 'right':
+      percentage = 100;
+      axis = 'x';
+      break;
+    case 'top':
+      percentage = 0;
+      axis = 'y';
+      break;
+    case 'bottom':
+      percentage = 100;
+      axis = 'y';
+      break;
+    case 'center':
+      percentage = 50;
+      break;
+    default:
+      // Logical keywords require knowledge about the inset property,
+      // as well as the writing direction of the floating element
+      // (or its containing block)
+      if (anchorEdge !== undefined && floatingEl) {
+        // @@@ `start` and `end` should use the writing-mode of the element's
+        // containing block, not the element itself
+        const isRTL = getComputedStyle(floatingEl).direction === 'rtl';
+        percentage = resolveLogicalKeyword(anchorEdge, isRTL);
+      }
+  }
+
+  const dir = getAxisProperty(axis);
+  if (
+    axis &&
+    dir &&
+    typeof percentage === 'number' &&
+    !Number.isNaN(percentage)
+  ) {
+    return `${anchorRect[axis] + (anchorRect[dir] * percentage) / 100}px`;
+  }
+
   return fallback;
 };
 
@@ -113,16 +198,18 @@ export function position(rules: AnchorPositions) {
               (resolve) => {
                 computePosition(anchor, floating, {
                   middleware: [
-                    offset(({ rects }) => {
+                    offset(({ elements, rects }) => {
                       resolve({
                         // @@@ Ideally we would directly replace these values
                         // in the CSS, so that we don't worry about the cascade,
-                        // and we could ignore `property` (e.g. handling `calc`)
-                        [property]: getPixelValue(
-                          rects.reference,
-                          anchorValue.anchorEdge,
-                          anchorValue.fallbackValue,
-                        ),
+                        // and we could usually ignore `property` entirely
+                        [property]: getPixelValue({
+                          floatingEl: elements.floating,
+                          anchorRect: rects.reference,
+                          anchorEdge: anchorValue.anchorEdge,
+                          floatingPosition: property,
+                          fallback: anchorValue.fallbackValue,
+                        }),
                       });
                       return 0;
                     }),

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -5,7 +5,6 @@ import { fetchCSS, isStyleLink } from './fetch.js';
 import {
   AnchorPositions,
   AnchorSide,
-  AnchorSideKeyword,
   getAST,
   isFallbackAtRule,
   isFallbackDeclaration,

--- a/tests/unit/parse.test.ts
+++ b/tests/unit/parse.test.ts
@@ -17,7 +17,7 @@ describe('parseCSS', () => {
           '--center': {
             anchorName: '--my-anchor',
             anchorEl: ['#my-anchor'],
-            anchorEdge: '50%',
+            anchorEdge: 50,
             fallbackValue: '0px',
           },
         },


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&22097)

This is an attempt to resolve `anchor()` fns directly to a pixel value, without reference to the floating-el property being declared. Ideally this will allow us to handle math/custom-css-var use-cases (e.g. `--center: anchor(--my-anchor 50%);`), `anchor-size`, etc.

See:

- https://github.com/oddbird/css-anchor-positioning/pull/19#discussion_r965070310
- https://github.com/oddbird/css-anchor-positioning/pull/19#discussion_r957481575