### PR TITLE
Validating anchor element

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CSS Anchor Positioning Polyfill Demo</title>
     <link type="text/css" href="/demo.css" />
-    <link rel="stylesheet" href="/anchor-positioning.css" />
-    <link rel="stylesheet" href="/parsing-test.css" />
-    <!-- <link type="text/css" href="/demo.css" /> -->
     <link rel="stylesheet" href="/anchor.css" />
     <link
       rel="stylesheet"

--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CSS Anchor Positioning Polyfill Demo</title>
     <link type="text/css" href="/demo.css" />
+    <link rel="stylesheet" href="/anchor-positioning.css" />
+    <link rel="stylesheet" href="/parsing-test.css" />
+    <!-- <link type="text/css" href="/demo.css" /> -->
     <link rel="stylesheet" href="/anchor.css" />
     <link
       rel="stylesheet"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
 export default {
-  timeout: process.env.CI ? undefined : 3000, // Max execution time of any single test
+  timeout: process.env.CI ? undefined : 5000, // Max execution time of any single test
   expect: {
     timeout: 1000, // Max execution time of single expect() calls
   },

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -129,39 +129,34 @@ export function position(rules: AnchorPositions) {
 
     Object.entries(position.declarations || {}).forEach(
       ([property, anchorValue]) => {
-        // @@@ For now, assume the first element is valid
-        if (anchorValue.anchorEl) {
-          const anchor = document.querySelector(anchorValue.anchorEl[0]);
-          if (anchor) {
-            const promise = new Promise<{ [key: string]: string }>(
-              (resolve) => {
-                computePosition(anchor, floating, {
-                  middleware: [
-                    offset(({ elements, rects }) => {
-                      resolve({
-                        // @@@ Ideally we would directly replace these values
-                        // in the CSS, so that we don't worry about the cascade,
-                        // and we could usually ignore `property` entirely
-                        [property]: getPixelValue({
-                          floatingEl: elements.floating,
-                          anchorRect: rects.reference,
-                          anchorEdge: anchorValue.anchorEdge,
-                          floatingPosition: property,
-                          fallback: anchorValue.fallbackValue,
-                        }),
-                      });
-                      return 0;
+        const anchor = anchorValue.anchorEl;
+        if (anchor) {
+          const promise = new Promise<{ [key: string]: string }>((resolve) => {
+            computePosition(anchor, floating, {
+              middleware: [
+                offset(({ elements, rects }) => {
+                  resolve({
+                    // @@@ Ideally we would directly replace these values
+                    // in the CSS, so that we don't worry about the cascade,
+                    // and we could usually ignore `property` entirely
+                    [property]: getPixelValue({
+                      floatingEl: elements.floating,
+                      anchorRect: rects.reference,
+                      anchorEdge: anchorValue.anchorEdge,
+                      floatingPosition: property,
+                      fallback: anchorValue.fallbackValue,
                     }),
-                  ],
-                });
-              },
-            );
-            // @@@ Figure out how to handle `autoUpdate`
-            autoUpdate(anchor, floating, () => {
-              console.log('re-calculate');
+                  });
+                  return 0;
+                }),
+              ],
             });
-            promises.push(promise);
-          }
+          });
+          // @@@ Figure out how to handle `autoUpdate`
+          autoUpdate(anchor, floating, () => {
+            console.log('re-calculate');
+          });
+          promises.push(promise);
         }
       },
     );

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -29,6 +29,31 @@ export function isAbsolutelyPositioned(el: HTMLElement) {
   );
 }
 
+export function hasDisplayNone(el: HTMLElement) {
+  return el.style.display === 'none' || getComputedStyle(el).display === 'none';
+}
+
+// Determines whether the containing block (CB) of the element is the initial containing block (ICB)
+// offsetParent returns null when the CB is the ICB, except in FF where offsetParent returns the body element
+// Excludes elements when they or their parents have display: none
+export function isContainingBlockICB(floatingElement: HTMLElement) {
+  const isDisplayNone =
+    hasDisplayNone(floatingElement) ||
+    hasDisplayNone(floatingElement.parentElement as HTMLElement);
+
+  const cbIsBodyElementFromFF =
+    floatingElement.offsetParent === document.querySelector('body') &&
+    navigator.userAgent.includes('Firefox');
+
+  const offsetParentNullOrBody =
+    floatingElement.offsetParent === null || cbIsBodyElementFromFF;
+
+  if (offsetParentNullOrBody && !isDisplayNone) {
+    return true;
+  }
+  return false;
+}
+
 // Validates that anchor element is a valid anchor for given floating element
 export function isValidAnchorElement(
   anchor: HTMLElement,
@@ -67,7 +92,7 @@ export function isValidAnchorElement(
   // or the querying element's containing block must be
   // the initial containing block:
   const isDescendant = Boolean(floating.offsetParent?.contains(anchor));
-  const floatingCBIsInitialCB = floating.offsetParent === null;
+  const floatingCBIsInitialCB = isContainingBlockICB(floating);
 
   if (isDescendant || floatingCBIsInitialCB) {
     return true;

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -22,24 +22,30 @@ export function validatedForPositioning(
   return null;
 }
 
-export function isAbsolutelyPositioned(el: HTMLElement) {
-  return (
-    el.style.position === 'absolute' ||
-    getComputedStyle(el).position === 'absolute'
+export function isAbsolutelyPositioned(el?: HTMLElement | null) {
+  return Boolean(
+    el &&
+      (el.style.position === 'absolute' ||
+        getComputedStyle(el).position === 'absolute'),
   );
 }
 
-export function hasDisplayNone(el: HTMLElement) {
-  return el.style.display === 'none' || getComputedStyle(el).display === 'none';
+export function hasDisplayNone(el?: HTMLElement | null) {
+  return Boolean(
+    el &&
+      (el.style.display === 'none' || getComputedStyle(el).display === 'none'),
+  );
 }
 
-// Determines whether the containing block (CB) of the element is the initial containing block (ICB)
-// offsetParent returns null when the CB is the ICB, except in FF where offsetParent returns the body element
-// Excludes elements when they or their parents have display: none
+// Determines whether the containing block (CB) of the element
+// is the initial containing block (ICB):
+// - `offsetParent` returns `null` when the CB is the ICB,
+//   except in Firefox where `offsetParent` returns the `body` element
+// - Excludes elements when they or their parents have `display: none`
 export function isContainingBlockICB(floatingElement: HTMLElement) {
   const isDisplayNone =
     hasDisplayNone(floatingElement) ||
-    hasDisplayNone(floatingElement.parentElement as HTMLElement);
+    hasDisplayNone(floatingElement.parentElement);
 
   const cbIsBodyElementFromFF =
     floatingElement.offsetParent === document.querySelector('body') &&
@@ -83,7 +89,7 @@ export function isValidAnchorElement(
     }
 
     const lastInChain = anchorCBchain[anchorCBchain.length - 1];
-    if (lastInChain && isAbsolutelyPositioned(lastInChain)) {
+    if (isAbsolutelyPositioned(lastInChain)) {
       return false;
     }
   }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,48 +1,55 @@
-/* eslint-disable no-warning-comments */
-
+// Given CSS selectors for a floating element and an anchor element,
+// returns elements that pass validation,
+// or `null` if no valid anchor element is found
 export function validatedForPositioning(
-  anchorName: string,
-  floatingName: string,
+  floatingEl: HTMLElement | null,
+  anchorSelectors: string[],
 ) {
-  const floatingElement = document.querySelector(floatingName) as HTMLElement;
-  const anchorElements = document.querySelectorAll(
-    anchorName,
-  ) as unknown as HTMLElement[];
-  const validAnchors: HTMLElement[] = [];
+  if (!floatingEl) {
+    return null;
+  }
 
-  anchorElements.forEach((anchor: HTMLElement) => {
-    if (validAnchorElement(anchor, floatingElement)) {
-      validAnchors.push(anchor);
+  const anchorElements: NodeListOf<HTMLElement> = document.querySelectorAll(
+    anchorSelectors.join(', '),
+  );
+
+  for (const anchor of anchorElements) {
+    if (isValidAnchorElement(anchor, floatingEl)) {
+      return anchor;
     }
-  });
+  }
 
-  return validAnchors.length
-    ? { anchor: validAnchors[0], floating: floatingElement }
-    : { anchor: null, floating: null };
+  return null;
 }
 
-export function validAnchorElement(
-  anchorElement: HTMLElement,
-  floatingElement: HTMLElement,
+// Validates that anchor element is a valid anchor for given floating element
+export function isValidAnchorElement(
+  anchor: HTMLElement,
+  floating: HTMLElement,
 ) {
-  // el has the same containing block as the querying element, el is not absolutely positioned
+  // el has the same containing block as the querying element,
+  // el is not absolutely positioned
   const anchorAbsolutelyPositioned =
-    anchorElement?.style.position === 'absolute' ||
-    getComputedStyle(anchorElement).position === 'aboslute';
+    anchor?.style.position === 'absolute' ||
+    getComputedStyle(anchor).position === 'absolute';
 
   if (
     anchorAbsolutelyPositioned &&
-    anchorElement.offsetParent === floatingElement.offsetParent
-  )
+    anchor.offsetParent === floating.offsetParent
+  ) {
     return false;
+  }
 
-  // el has a different containing block from the querying element, the last containing block in el’s containing block chain before reaching the querying element’s containing block is not absolutely positioned
-  if (anchorElement.offsetParent != floatingElement.offsetParent) {
+  // el has a different containing block from the querying element,
+  // the last containing block in el’s containing block chain
+  // before reaching the querying element’s containing block
+  // is not absolutely positioned
+  if (anchor.offsetParent != floating.offsetParent) {
     let currentCB: HTMLElement | null;
     const anchorCBchain: HTMLElement[] = [];
 
-    currentCB = anchorElement.offsetParent as HTMLElement;
-    while (currentCB && currentCB != floatingElement.offsetParent) {
+    currentCB = anchor.offsetParent as HTMLElement;
+    while (currentCB && currentCB != floating.offsetParent) {
       anchorCBchain.push(currentCB);
       currentCB = currentCB?.offsetParent as HTMLElement;
     }
@@ -56,15 +63,14 @@ export function validAnchorElement(
     }
   }
 
-  // el is a descendant of the querying element’s containing block, or the quering element’s containing block is the initial containing block
-  const descendant = floatingElement?.offsetParent?.contains(anchorElement);
-  const floatingCBIsInitialCB = floatingElement?.offsetParent === null;
+  // el is a descendant of the querying element’s containing block,
+  // or the quering element’s containing block is the initial containing block
+  const descendant = floating?.offsetParent?.contains(anchor);
+  const floatingCBIsInitialCB = floating?.offsetParent === null;
 
-  if (descendant || floatingCBIsInitialCB) return true;
+  if (descendant || floatingCBIsInitialCB) {
+    return true;
+  }
 
   return false;
 }
-
-// export function validAnchorQuery(anchorQuery) {
-//   return false;
-// }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-warning-comments */
+
+export function validatedForPositioning(
+  anchorName: string,
+  floatingName: string,
+) {
+  const floatingElement = document.querySelector(floatingName) as HTMLElement;
+  const anchorElements = document.querySelectorAll(
+    anchorName,
+  ) as unknown as HTMLElement[];
+  const validAnchors: HTMLElement[] = [];
+
+  anchorElements.forEach((anchor: HTMLElement) => {
+    if (validAnchorElement(anchor, floatingElement)) {
+      validAnchors.push(anchor);
+    }
+  });
+
+  return validAnchors.length
+    ? { anchor: validAnchors[0], floating: floatingElement }
+    : { anchor: null, floating: null };
+}
+
+export function validAnchorElement(
+  anchorElement: HTMLElement,
+  floatingElement: HTMLElement,
+) {
+  // el has the same containing block as the querying element, el is not absolutely positioned
+  const anchorAbsolutelyPositioned =
+    anchorElement?.style.position === 'absolute' ||
+    getComputedStyle(anchorElement).position === 'aboslute';
+
+  if (
+    anchorAbsolutelyPositioned &&
+    anchorElement.offsetParent === floatingElement.offsetParent
+  )
+    return false;
+
+  // el has a different containing block from the querying element, the last containing block in el’s containing block chain before reaching the querying element’s containing block is not absolutely positioned
+  if (anchorElement.offsetParent != floatingElement.offsetParent) {
+    let currentCB: HTMLElement | null;
+    const anchorCBchain: HTMLElement[] = [];
+
+    currentCB = anchorElement.offsetParent as HTMLElement;
+    while (currentCB && currentCB != floatingElement.offsetParent) {
+      anchorCBchain.push(currentCB);
+      currentCB = currentCB?.offsetParent as HTMLElement;
+    }
+
+    const lastInChain = anchorCBchain[anchorCBchain.length - 1];
+    if (
+      lastInChain?.style.position === 'absolute' ||
+      getComputedStyle(lastInChain).position === 'absolute'
+    ) {
+      return false;
+    }
+  }
+
+  // el is a descendant of the querying element’s containing block, or the quering element’s containing block is the initial containing block
+  const descendant = floatingElement?.offsetParent?.contains(anchorElement);
+  const floatingCBIsInitialCB = floatingElement?.offsetParent === null;
+
+  if (descendant || floatingCBIsInitialCB) return true;
+
+  return false;
+}
+
+// export function validAnchorQuery(anchorQuery) {
+//   return false;
+// }

--- a/tests/e2e/validate.test.ts
+++ b/tests/e2e/validate.test.ts
@@ -1,7 +1,7 @@
-// import { expect, Page, test } from '@playwright/test';
 import { type Page, expect, test } from '@playwright/test';
 
 import {
+  isAbsolutelyPositioned,
   isValidAnchorElement,
   validatedForPositioning,
 } from '../../src/validate.js';
@@ -12,7 +12,7 @@ test.beforeAll(async ({ browser }) => {
   sharedPage = await browser.newPage();
   await sharedPage.goto('/');
   await sharedPage.addScriptTag({
-    content: `${isValidAnchorElement}`,
+    content: `${isAbsolutelyPositioned}\n${isValidAnchorElement}`,
   });
 });
 
@@ -36,8 +36,9 @@ async function callValidFunction(sharedPage: Page) {
   );
 }
 
-// el is a descendant of the querying element’s containing block, or the quering element’s containing block is the initial containing block
-test('anchor is valid when its is a descendant of the query element CB', async () => {
+// el is a descendant of the querying element’s containing block,
+// or the querying element’s containing block is the initial containing block
+test("anchor is valid when it's is a descendant of the query element CB", async () => {
   await sharedPage.setContent(
     `
       <!DOCTYPE html>
@@ -62,8 +63,9 @@ test('anchor is valid when its is a descendant of the query element CB', async (
   expect(result).toBe(true);
 });
 
-// el is a descendant of the querying element’s containing block, or the quering element’s containing block is the initial containing block
-test('anchor is valid if its not descendant of query element CB but query element CB is ICB', async () => {
+// el is a descendant of the querying element’s containing block,
+// or the querying element’s containing block is the initial containing block
+test("anchor is valid if it's not descendant of query element CB but query element CB is ICB", async () => {
   await sharedPage.setContent(
     `
       <div style="position: relative>
@@ -84,7 +86,7 @@ test('anchor is valid if its not descendant of query element CB but query elemen
   expect(result).toBe(true);
 });
 
-test('anchor is valid if its not descendant of query element CB and query element CB is the ICB - position: fixed', async () => {
+test("anchor is valid if it's not descendant of query element CB and query element CB is the ICB - position: fixed", async () => {
   await sharedPage.setContent(
     `
       <div id="my-floating-positioning" style="position: fixed">
@@ -116,7 +118,7 @@ test('anchor not descendant of query element CB and query element CB is the ICB 
   expect(result).toBe(true);
 });
 
-test('anchor is NOT valid if its not descendant of query element CB AND query element CB is not ICB', async () => {
+test("anchor is NOT valid if it's not descendant of query element CB AND query element CB is not ICB", async () => {
   await sharedPage.setContent(
     `
       <div style="position: relative">
@@ -140,7 +142,8 @@ test('anchor is NOT valid if its not descendant of query element CB AND query el
   expect(result).toBe(false);
 });
 
-// if el has the same containing block as the querying element, el is not absolutely positioned
+// if el has the same containing block as the querying element,
+// el is not absolutely positioned
 test('anchor is valid when anchor has same CB as querying element and anchor is not absolutely positioned', async () => {
   await sharedPage.setContent(
     `
@@ -173,7 +176,10 @@ test('anchor is NOT valid when anchor has same CB as querying element, but ancho
   expect(result).toBe(false);
 });
 
-// if el has a different containing block from the querying element, the last containing block in el’s containing block chain before reaching the querying element’s containing block is not absolutely positioned
+// if el has a different containing block from the querying element,
+// the last containing block in el’s containing block chain
+// before reaching the querying element’s containing block
+// is not absolutely positioned
 test('anchor is valid if it has a different CB from the querying element, and the last CB in anchor CB chain block before the query element CB is not absolutely positioned', async () => {
   // HTML from WPT: https://github.com/web-platform-tests/wpt/blob/master/css/css-anchor-position/anchor-name-002.tentative.html
   await sharedPage.setContent(

--- a/tests/e2e/validate.test.ts
+++ b/tests/e2e/validate.test.ts
@@ -1,0 +1,372 @@
+// import { expect, Page, test } from '@playwright/test';
+import { type Page, expect, test } from '@playwright/test';
+
+import {
+  validAnchorElement,
+  validatedForPositioning,
+} from '../../src/validate.js';
+
+let sharedPage: Page;
+test.describe.configure({ mode: 'parallel' });
+test.beforeAll(async ({ browser }) => {
+  sharedPage = await browser.newPage();
+  await sharedPage.goto('/');
+  await sharedPage.addScriptTag({
+    content: `${validAnchorElement}`,
+  });
+});
+
+test.afterAll(async () => {
+  await sharedPage.close();
+});
+
+const anchorName = '#my-anchor-positioning';
+const floatingName = '#my-floating-positioning';
+
+async function callValidFunction(sharedPage: Page) {
+  return await sharedPage.evaluate(
+    ([anchorName, floatingName]) => {
+      const floatingElement = document.querySelector(
+        floatingName,
+      ) as HTMLElement;
+      const anchorElement = document.querySelector(anchorName) as HTMLElement;
+      return validAnchorElement(anchorElement, floatingElement);
+    },
+    [anchorName, floatingName],
+  );
+}
+
+// el is a descendant of the querying element’s containing block, or the quering element’s containing block is the initial containing block
+test('anchor is valid when its is a descendant of the query element CB', async () => {
+  await sharedPage.setContent(
+    `
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      </head>
+      <body>
+        <div style="position: relative">
+          <div id="my-anchor-positioning">Anchor</div>
+          <div id="my-floating-positioning">Floating</div>
+        </div>
+      </body>
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  const result = await callValidFunction(sharedPage);
+
+  expect(result).toBe(true);
+});
+
+// el is a descendant of the querying element’s containing block, or the quering element’s containing block is the initial containing block
+test('anchor is valid if its not descendant of query element CB but query element CB is ICB', async () => {
+  await sharedPage.setContent(
+    `
+      <div style="position: relative>
+        <div id="my-other-anchor-positioning">Anchor</div>
+        <div id="my-other-floating-positioning">Floating</div>
+      </div>
+
+      <div id="my-anchor-positioning">Anchor</div>
+      
+      <div id="my-floating-positioning">Floating<div>
+
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  const result = await callValidFunction(sharedPage);
+
+  expect(result).toBe(true);
+});
+
+test('anchor is valid if its not descendant of query element CB and query element CB is the ICB - position: fixed', async () => {
+  await sharedPage.setContent(
+    `
+      <div id="my-floating-positioning" style="position: fixed">
+        Floating
+      </div>
+      <div id="my-anchor-positioning">Anchor</div>
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  const result = await callValidFunction(sharedPage);
+
+  expect(result).toBe(true);
+});
+
+test('anchor not descendant of query element CB and query element CB is the ICB - no positioned ancestor', async () => {
+  await sharedPage.setContent(
+    `
+      <div id="my-floating-positioning">
+        Floating
+      </div>
+      <div id="my-anchor-positioning">Anchor</div>
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  const result = await callValidFunction(sharedPage);
+
+  expect(result).toBe(true);
+});
+
+test('anchor is NOT valid if its not descendant of query element CB AND query element CB is not ICB', async () => {
+  await sharedPage.setContent(
+    `
+      <div style="position: relative">
+        <div id="my-other-anchor-positioning">Anchor</div>
+        <div id="my-other-floating-positioning">Floating</div>
+      </div>
+
+      <div style="position: relative">
+        <div id="my-anchor-positioning">Anchor</div>
+      </div>
+      
+      <div style="position: relative">
+        <div id="my-floating-positioning">Floating<div>
+      </div>
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  const result = await callValidFunction(sharedPage);
+
+  expect(result).toBe(false);
+});
+
+// if el has the same containing block as the querying element, el is not absolutely positioned
+test('anchor is valid when anchor has same CB as querying element and anchor is not absolutely positioned', async () => {
+  await sharedPage.setContent(
+    `
+  <div style="position: relative">
+    <div id="my-anchor-positioning">Anchor</div>
+    <div id="my-floating-positioning">Floating</div>
+  </div>;
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  const result = await callValidFunction(sharedPage);
+
+  expect(result).toBe(true);
+});
+
+test('anchor is NOT valid when anchor has same CB as querying element, but anchor is absolutely positioned', async () => {
+  await sharedPage.setContent(
+    `
+  <div style="position: relative">
+    <div id="my-anchor-positioning" style="position: absolute">Anchor</div>
+    <div id="my-floating-positioning">Floating</div>
+  </div>;
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  const result = await callValidFunction(sharedPage);
+
+  expect(result).toBe(false);
+});
+
+// if el has a different containing block from the querying element, the last containing block in el’s containing block chain before reaching the querying element’s containing block is not absolutely positioned
+test('anchor is valid if it has a different CB from the querying element, and the last CB in anchor CB chain block before the query element CB is not absolutely positioned', async () => {
+  // HTML from WPT: https://github.com/web-platform-tests/wpt/blob/master/css/css-anchor-position/anchor-name-002.tentative.html
+  await sharedPage.setContent(
+    `
+    <style>
+      .relpos {
+        position: relative;
+      }
+      .abspos {
+        position: absolute;
+      }
+      .anchor1 {
+        anchor-name: --a1;
+        width: 10px;
+        height: 10px;
+        background: orange;
+      }
+      .target {
+        position: absolute;
+        width: anchor-size(--a1 width);
+        height: 10px;
+        background: lime;
+      }
+  </style>
+
+    <div class="relpos">
+      <div>
+        <div class="relpos">
+          <div class="abspos">
+            <div class="relpos">
+              <div
+                class="anchor1"
+                style="position: absolute"
+                id="my-anchor-positioning"
+              ></div>
+              <!-- This target should not find the anchor, because the anchor is
+                  positioned. -->
+              <div class="target" data-expected-width="0"></div>
+            </div>
+            <!-- This target should find the anchor, because the last containing
+                block has position: relative. -->
+            <div
+              class="target"
+              data-expected-width="10"
+              id="my-floating-positioning"
+            ></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  const result = await callValidFunction(sharedPage);
+
+  expect(result).toBe(true);
+});
+
+test('anchor is NOT valid if it has a different CB from the querying element, and the last CB in anchor CB chain before the query element CB is absolutely positioned', async () => {
+  // HTML from WPT: https://github.com/web-platform-tests/wpt/blob/master/css/css-anchor-position/anchor-name-002.tentative.html
+  await sharedPage.setContent(
+    `
+  <!DOCTYPE html>
+
+    <style>
+      .relpos {
+        position: relative;
+      }
+      .abspos {
+        position: absolute;
+      }
+      .anchor1 {
+        anchor-name: --a1;
+        width: 10px;
+        height: 10px;
+        background: orange;
+      }
+      .target {
+        position: absolute;
+        width: anchor-size(--a1 width);
+        height: 10px;
+        background: lime;
+      }
+    </style>
+    <body>
+      <div class="relpos"> Rel 1
+        <div>
+          <div class="relpos">Rel 1
+            <div class="abspos"> Abs 1
+              <div class="abspos"> Abs 2
+                <div
+                  class="anchor1"
+                  style="position: absolute"
+                  id="my-anchor-positioning"
+                ></div>
+                <!-- This target should not find the anchor, because the anchor is
+                    positioned. -->
+                <div class="target" data-expected-width="0"></div>
+              </div>
+              <!-- This target should find the anchor, because the last containing
+                  block has position: relative. -->
+              <div
+                class="target"
+                data-expected-width="10"
+                id="my-floating-positioning"
+              ></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </body>
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  const result = await callValidFunction(sharedPage);
+
+  expect(result).toBe(false);
+});
+
+test('when multiple anchor elements have the same name and are valid, the first is returned', async () => {
+  // HTML from WPT: https://github.com/web-platform-tests/wpt/blob/master/css/css-anchor-position/anchor-name-001.tentative.html
+  await sharedPage.setContent(
+    `
+    <style>
+    .relpos {
+      position: relative;
+    }
+    .anchor1 {
+      anchor-name: --a1;
+      width: 10px;
+      height: 10px;
+      background: orange;
+    }
+    .target {
+      position: absolute;
+      width: anchor-size(--a1 width);
+      height: 10px;
+      background: lime;
+    }
+    </style>
+    <body onload="checkLayout('.target')">
+      <!--
+        All targets should find the 10px anchor, because it's the first
+        one in the pre-order DFS from the 'relpos'.
+      -->
+      <div class="relpos">
+        <div class="target" data-expected-width=10 id="my-floating-positioning">My Floating Element</div>
+        <div class="anchor1" id="my-anchor-positioning" style="width: 10px">First Anchor Element
+          <div class="anchor1" id="my-anchor-positioning" style="width: 20px">Second Anchor Element</div>
+          <div class="target" data-expected-width=10></div>
+        </div>
+        <div class="anchor1" id="my-anchor-positioning" style="width: 30px">Third Anchor Element</div>
+        <div class="target" data-expected-width=10></div>
+      <div>
+    </body>
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  await sharedPage.addScriptTag({
+    content: `${validatedForPositioning}`,
+  });
+
+  const valid = await callValidFunction(sharedPage);
+  expect(valid).toBe(true);
+
+  const validationResults = await sharedPage.evaluate(
+    ([anchorName, floatingName]) => {
+      interface Data {
+        results: {
+          anchor: HTMLElement | null;
+          floating: HTMLElement | null;
+        };
+        anchorWidth: string | undefined;
+        anchorText: string | undefined;
+      }
+
+      const validatedData = {} as Data;
+      const validateResults = validatedForPositioning(anchorName, floatingName);
+
+      validatedData.results = validateResults;
+      validatedData.anchorWidth = validateResults.anchor?.style.width;
+      validatedData.anchorText = validateResults.anchor?.innerHTML;
+
+      return validatedData;
+    },
+    [anchorName, floatingName],
+  );
+
+  expect(validationResults.results.anchor).toBeTruthy;
+  expect(validationResults.results.floating).toBeTruthy;
+  expect(validationResults.anchorText).toContain('First Anchor Element');
+  expect(validationResults.anchorWidth).toBe('10px');
+});

--- a/tests/e2e/validate.test.ts
+++ b/tests/e2e/validate.test.ts
@@ -1,7 +1,9 @@
 import { type Page, expect, test } from '@playwright/test';
 
 import {
+  hasDisplayNone,
   isAbsolutelyPositioned,
+  isContainingBlockICB,
   isValidAnchorElement,
   validatedForPositioning,
 } from '../../src/validate.js';
@@ -12,7 +14,7 @@ test.beforeAll(async ({ browser }) => {
   sharedPage = await browser.newPage();
   await sharedPage.goto('/');
   await sharedPage.addScriptTag({
-    content: `${isAbsolutelyPositioned}\n${isValidAnchorElement}`,
+    content: `${isAbsolutelyPositioned}\n${isValidAnchorElement}\n${isContainingBlockICB}\n${hasDisplayNone}`,
   });
 });
 
@@ -102,7 +104,7 @@ test("anchor is valid if it's not descendant of query element CB and query eleme
   expect(result).toBe(true);
 });
 
-test('anchor not descendant of query element CB and query element CB is the ICB - no positioned ancestor', async () => {
+test('anchor is valid if it is not descendant of query element CB and query element CB is the ICB - no positioned ancestor', async () => {
   await sharedPage.setContent(
     `
       <div id="my-floating-positioning">
@@ -133,6 +135,22 @@ test("anchor is NOT valid if it's not descendant of query element CB AND query e
       <div style="position: relative">
         <div id="my-floating-positioning">Floating<div>
       </div>
+  `,
+    { waitUntil: 'domcontentloaded' },
+  );
+
+  const result = await callValidFunction(sharedPage);
+
+  expect(result).toBe(false);
+});
+
+test("anchor is NOT valid if it's not descendant of query element CB AND query element CB is not ICB - display:none", async () => {
+  await sharedPage.setContent(
+    `
+      <div id="my-floating-positioning" style="display:none">
+        Floating
+      </div>
+      <div id="my-anchor-positioning">Anchor</div>
   `,
     { waitUntil: 'domcontentloaded' },
   );

--- a/tests/e2e/validate.test.ts
+++ b/tests/e2e/validate.test.ts
@@ -2,7 +2,7 @@
 import { type Page, expect, test } from '@playwright/test';
 
 import {
-  validAnchorElement,
+  isValidAnchorElement,
   validatedForPositioning,
 } from '../../src/validate.js';
 
@@ -12,7 +12,7 @@ test.beforeAll(async ({ browser }) => {
   sharedPage = await browser.newPage();
   await sharedPage.goto('/');
   await sharedPage.addScriptTag({
-    content: `${validAnchorElement}`,
+    content: `${isValidAnchorElement}`,
   });
 });
 
@@ -30,7 +30,7 @@ async function callValidFunction(sharedPage: Page) {
         floatingName,
       ) as HTMLElement;
       const anchorElement = document.querySelector(anchorName) as HTMLElement;
-      return validAnchorElement(anchorElement, floatingElement);
+      return isValidAnchorElement(anchorElement, floatingElement);
     },
     [anchorName, floatingName],
   );
@@ -72,7 +72,7 @@ test('anchor is valid if its not descendant of query element CB but query elemen
       </div>
 
       <div id="my-anchor-positioning">Anchor</div>
-      
+
       <div id="my-floating-positioning">Floating<div>
 
   `,
@@ -127,7 +127,7 @@ test('anchor is NOT valid if its not descendant of query element CB AND query el
       <div style="position: relative">
         <div id="my-anchor-positioning">Anchor</div>
       </div>
-      
+
       <div style="position: relative">
         <div id="my-floating-positioning">Floating<div>
       </div>
@@ -347,18 +347,21 @@ test('when multiple anchor elements have the same name and are valid, the first 
       interface Data {
         results: {
           anchor: HTMLElement | null;
-          floating: HTMLElement | null;
         };
         anchorWidth: string | undefined;
         anchorText: string | undefined;
       }
 
-      const validatedData = {} as Data;
-      const validateResults = validatedForPositioning(anchorName, floatingName);
+      const floatingElement = document.querySelector(
+        floatingName,
+      ) as HTMLElement;
 
-      validatedData.results = validateResults;
-      validatedData.anchorWidth = validateResults.anchor?.style.width;
-      validatedData.anchorText = validateResults.anchor?.innerHTML;
+      const validatedData = {} as Data;
+      const anchor = validatedForPositioning(floatingElement, [anchorName]);
+
+      validatedData.results = { anchor };
+      validatedData.anchorWidth = anchor?.style.width;
+      validatedData.anchorText = anchor?.innerHTML;
 
       return validatedData;
     },
@@ -366,7 +369,6 @@ test('when multiple anchor elements have the same name and are valid, the first 
   );
 
   expect(validationResults.results.anchor).toBeTruthy;
-  expect(validationResults.results.floating).toBeTruthy;
   expect(validationResults.anchorText).toContain('First Anchor Element');
   expect(validationResults.anchorWidth).toBe('10px');
 });

--- a/tests/unit/parse.test.ts
+++ b/tests/unit/parse.test.ts
@@ -9,6 +9,8 @@ describe('parseCSS', () => {
   });
 
   it('parses `anchor()` function (math)', () => {
+    document.body.innerHTML =
+      '<div id="my-floating"></div><div id="my-anchor"></div>';
     const css = getSampleCSS('anchor');
     const result = parseCSS(css);
     const expected = {
@@ -16,7 +18,7 @@ describe('parseCSS', () => {
         declarations: {
           '--center': {
             anchorName: '--my-anchor',
-            anchorEl: ['#my-anchor'],
+            anchorEl: document.getElementById('my-anchor'),
             anchorEdge: 50,
             fallbackValue: '0px',
           },
@@ -28,6 +30,9 @@ describe('parseCSS', () => {
   });
 
   it('parses `anchor()` function (positioning)', () => {
+    document.body.innerHTML =
+      '<div id="my-floating-positioning"></div><div id="my-anchor-positioning"></div>';
+    const anchorEl = document.getElementById('my-anchor-positioning');
     const css = getSampleCSS('anchor-positioning');
     const result = parseCSS(css);
     const expected = {
@@ -35,13 +40,13 @@ describe('parseCSS', () => {
         declarations: {
           top: {
             anchorName: '--my-anchor-positioning',
-            anchorEl: ['#my-anchor-positioning'],
+            anchorEl,
             anchorEdge: 'bottom',
             fallbackValue: '0px',
           },
           left: {
             anchorName: '--my-anchor-positioning',
-            anchorEl: ['#my-anchor-positioning'],
+            anchorEl,
             anchorEdge: 'right',
             fallbackValue: '50px',
           },
@@ -53,6 +58,9 @@ describe('parseCSS', () => {
   });
 
   it('parses `@position-fallback` strategy', () => {
+    document.body.innerHTML =
+      '<div id="my-floating-fallback"></div><div id="my-anchor-fallback"></div>';
+    const anchorEl = document.getElementById('my-anchor-fallback');
     const css = getSampleCSS('position-fallback');
     const result = parseCSS(css);
     const expected = {
@@ -60,7 +68,7 @@ describe('parseCSS', () => {
         declarations: {
           left: {
             anchorName: '--my-anchor-fallback',
-            anchorEl: ['#my-anchor-fallback'],
+            anchorEl,
             anchorEdge: 'left',
             fallbackValue: '0px',
           },
@@ -69,13 +77,13 @@ describe('parseCSS', () => {
           {
             left: {
               anchorName: '--my-anchor-fallback',
-              anchorEl: ['#my-anchor-fallback'],
+              anchorEl,
               anchorEdge: 'right',
               fallbackValue: '10px',
             },
             top: {
               anchorName: '--my-anchor-fallback',
-              anchorEl: ['#my-anchor-fallback'],
+              anchorEl,
               anchorEdge: 'top',
               fallbackValue: '0px',
             },
@@ -83,13 +91,13 @@ describe('parseCSS', () => {
           {
             right: {
               anchorName: '--my-anchor-fallback',
-              anchorEl: ['#my-anchor-fallback'],
+              anchorEl,
               anchorEdge: 'left',
               fallbackValue: '0px',
             },
             top: {
               anchorName: '--my-anchor-fallback',
-              anchorEl: ['#my-anchor-fallback'],
+              anchorEl,
               anchorEdge: 'top',
               fallbackValue: '0px',
             },
@@ -97,13 +105,13 @@ describe('parseCSS', () => {
           {
             left: {
               anchorName: '--my-anchor-fallback',
-              anchorEl: ['#my-anchor-fallback'],
+              anchorEl,
               anchorEdge: 'left',
               fallbackValue: '0px',
             },
             top: {
               anchorName: '--my-anchor-fallback',
-              anchorEl: ['#my-anchor-fallback'],
+              anchorEl,
               anchorEdge: 'bottom',
               fallbackValue: '0px',
             },
@@ -111,13 +119,13 @@ describe('parseCSS', () => {
           {
             left: {
               anchorName: '--my-anchor-fallback',
-              anchorEl: ['#my-anchor-fallback'],
+              anchorEl,
               anchorEdge: 'left',
               fallbackValue: '0px',
             },
             bottom: {
               anchorName: '--my-anchor-fallback',
-              anchorEl: ['#my-anchor-fallback'],
+              anchorEl,
               anchorEdge: 'top',
               fallbackValue: '0px',
             },
@@ -125,13 +133,13 @@ describe('parseCSS', () => {
           {
             left: {
               anchorName: '--my-anchor-fallback',
-              anchorEl: ['#my-anchor-fallback'],
+              anchorEl,
               anchorEdge: 'right',
               fallbackValue: '0px',
             },
             top: {
               anchorName: '--my-anchor-fallback',
-              anchorEl: ['#my-anchor-fallback'],
+              anchorEl,
               anchorEdge: 'top',
               fallbackValue: '0px',
             },
@@ -146,6 +154,8 @@ describe('parseCSS', () => {
   });
 
   it('handles duplicate anchor-names', () => {
+    document.body.innerHTML = '<div id="f1"></div><div id="a2"></div>';
+    const anchorEl = document.getElementById('a2');
     const css = `
       #a1 {
         anchor-name: --my-anchor;
@@ -164,7 +174,7 @@ describe('parseCSS', () => {
         declarations: {
           top: {
             anchorName: '--my-anchor',
-            anchorEl: ['#a1', '#a2'],
+            anchorEl,
             anchorEdge: 'bottom',
             fallbackValue: '0px',
           },


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?bird&cute)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
- Given a name for an anchor and a name for a floating element (presumably from our parsing step) - this validates whether the anchor element is valid according to the criteria outlined in the spec
- If multiple elements are found with that anchor name, then the first one that is valid is returned along with the floating element from the `validatedForPositioning` function. This is written that this function is what is called before positioning and then positioning uses these elements moving forward. Will return null for the `anchor` and `floating` properties if no valid set found.
- Most of the logic for validation is in the `validAnchorElement` function which goes through the criteria of the spec


