### PR TITLE
Fix bugs with unknown anchor names

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -344,10 +344,9 @@ export function parseCSS(css: string) {
         for (const [prop, value] of Object.entries(tryBlock)) {
           if (typeof value === 'object') {
             const anchorName = (value as AnchorFunction).anchorName;
-            const anchorSelectors =
-              anchorName && anchorName in anchorNames
-                ? anchorNames[anchorName]
-                : [];
+            const anchorSelectors = anchorName
+              ? anchorNames[anchorName] ?? []
+              : [];
             const anchorEl = validatedForPositioning(targetEl, anchorSelectors);
             (tryBlock[prop] as AnchorFunction).anchorEl = anchorEl;
           }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -344,7 +344,10 @@ export function parseCSS(css: string) {
         for (const [prop, value] of Object.entries(tryBlock)) {
           if (typeof value === 'object') {
             const anchorName = (value as AnchorFunction).anchorName;
-            const anchorSelectors = anchorName ? anchorNames[anchorName] : [];
+            const anchorSelectors =
+              anchorName && anchorName in anchorNames
+                ? anchorNames[anchorName]
+                : [];
             const anchorEl = validatedForPositioning(targetEl, anchorSelectors);
             (tryBlock[prop] as AnchorFunction).anchorEl = anchorEl;
           }
@@ -361,9 +364,10 @@ export function parseCSS(css: string) {
     const targetEl: HTMLElement | null = document.querySelector(targetSel);
     for (const [targetProperty, anchorObj] of Object.entries(anchorFns)) {
       // Populate `anchorEl` for each `anchor()` fn
-      const anchorSelectors = anchorObj.anchorName
-        ? anchorNames[anchorObj.anchorName]
-        : [];
+      const anchorSelectors =
+        anchorObj.anchorName && anchorObj.anchorName in anchorNames
+          ? anchorNames[anchorObj.anchorName]
+          : [];
       validPositions[targetSel] = {
         ...validPositions[targetSel],
         declarations: {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -363,10 +363,9 @@ export function parseCSS(css: string) {
     const targetEl: HTMLElement | null = document.querySelector(targetSel);
     for (const [targetProperty, anchorObj] of Object.entries(anchorFns)) {
       // Populate `anchorEl` for each `anchor()` fn
-      const anchorSelectors =
-        anchorObj.anchorName && anchorObj.anchorName in anchorNames
-          ? anchorNames[anchorObj.anchorName]
-          : [];
+      const anchorSelectors = anchorObj.anchorName
+        ? anchorNames[anchorObj.anchorName] ?? []
+        : [];
       validPositions[targetSel] = {
         ...validPositions[targetSel],
         declarations: {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -5,7 +5,7 @@ export function validatedForPositioning(
   targetEl: HTMLElement | null,
   anchorSelectors: string[],
 ) {
-  if (!targetEl) {
+  if (!targetEl || anchorSelectors.length == 0) {
     return null;
   }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -5,7 +5,7 @@ export function validatedForPositioning(
   targetEl: HTMLElement | null,
   anchorSelectors: string[],
 ) {
-  if (!targetEl || anchorSelectors.length == 0) {
+  if (!targetEl || anchorSelectors.length === 0) {
     return null;
   }
 

--- a/tests/unit/parse.test.ts
+++ b/tests/unit/parse.test.ts
@@ -8,6 +8,31 @@ describe('parseCSS', () => {
     expect(result).toEqual({});
   });
 
+  it('parses `anchor()` function with unknown anchor name', () => {
+    document.body.innerHTML = '<div id="f1"></div>';
+    const css = `
+      #f1 {
+        position: absolute;
+        top: anchor(--my-anchor bottom);
+      }
+    `;
+    const result = parseCSS(css);
+    const expected = {
+      '#f1': {
+        declarations: {
+          top: {
+            anchorName: '--my-anchor',
+            anchorEl: null,
+            anchorEdge: 'bottom',
+            fallbackValue: '0px',
+          },
+        },
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+
   it('parses `anchor()` function (custom properties)', () => {
     document.body.innerHTML =
       '<div id="my-target"></div><div id="my-anchor"></div>';
@@ -215,6 +240,46 @@ describe('parseCSS', () => {
             },
             width: '35px',
             height: '40px',
+          },
+        ],
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  it('parses `@position-fallback` with unknown anchor name', () => {
+    document.body.innerHTML = '<div id="my-target-fallback"></div>';
+    const css = `
+      #my-target-fallback {
+        position: absolute;
+        position-fallback: --fallback1;
+      }
+
+      @position-fallback --fallback1 {
+        @try {
+          left: anchor(--my-anchor-fallback right, 10px);
+          top: anchor(--my-anchor-fallback top);
+        }
+      }
+    `;
+    const result = parseCSS(css);
+    const expected = {
+      '#my-target-fallback': {
+        fallbacks: [
+          {
+            left: {
+              anchorName: '--my-anchor-fallback',
+              anchorEl: null,
+              anchorEdge: 'right',
+              fallbackValue: '10px',
+            },
+            top: {
+              anchorName: '--my-anchor-fallback',
+              anchorEl: null,
+              anchorEdge: 'top',
+              fallbackValue: '0px',
+            },
           },
         ],
       },


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&somerandomstringdunno)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
It used to be the case that an unknown anchor name would throw an exception. This change fixes that.



## Steps to test/reproduce
Use the `anchor()` function with an anchor name that hasn't been defined anywhere. For example, `left: anchor(--test right)`, with no element having `anchor-name: --test`.


## Show me
_Provide screenshots/animated gifs/videos if necessary._


# REMEMBER: Attach this PR to the Trello card
