### PR TITLE
Support specifying anchor name via CSS custom property.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,15 +8,12 @@
     <link rel="stylesheet" href="https://unpkg.com/open-props" />
     <link rel="stylesheet" href="/demo.css" />
     <link rel="stylesheet" href="/anchor.css" />
-    <link
-      rel="stylesheet"
-      data-style-anchor-positioning
-      href="/anchor-positioning.css"
-    />
+    <link rel="stylesheet" href="/anchor-positioning.css" />
     <link rel="stylesheet" href="/position-fallback.css" />
     <link rel="stylesheet" href="/anchor-scroll.css" />
     <link rel="stylesheet" href="/anchor-size.css" />
     <link rel="stylesheet" href="/anchor-math.css" />
+    <link rel="stylesheet" href="/anchor-name-custom-prop.css" />
     <style>
       #my-anchor-style-tag {
         anchor-name: --my-anchor-style-tag;
@@ -347,7 +344,7 @@
     <section id="custom-prop" class="demo-item">
       <h2>
         <a href="#custom-prop" aria-hidden="true">🔗</a>
-        Anchor() [used in CSS custom property]
+        Anchor() [assigned to CSS custom property]
       </h2>
       <div style="position: relative" class="demo-elements">
         <div id="my-anchor" class="anchor">Anchor</div>
@@ -370,6 +367,33 @@
   position: absolute;
   top: var(--center);
   right: var(--full);
+}</pre
+      >
+    </section>
+    <section id="custom-prop-name" class="demo-item">
+      <h2>
+        <a href="#custom-prop-name" aria-hidden="true">🔗</a>
+        Anchor() [with anchor name set as CSS custom property]
+      </h2>
+      <div style="position: relative" class="demo-elements">
+        <div id="my-anchor-name-prop" class="anchor">Anchor</div>
+        <div id="my-target-name-prop" class="target">Target</div>
+      </div>
+      <p class="note">
+        With polyfill applied: Target is positioned at the top left corner of
+        the Anchor.
+      </p>
+      <pre>
+#my-anchor-name-prop {
+  anchor-name: --my-anchor-name-prop;
+}
+
+#my-target-name-prop {
+  --anchor-var: --my-anchor-name-prop;
+
+  position: absolute;
+  right: anchor(var(--anchor-var) left);
+  bottom: anchor(var(--anchor-var) top);
 }</pre
       >
     </section>

--- a/public/anchor-name-custom-prop.css
+++ b/public/anchor-name-custom-prop.css
@@ -1,0 +1,11 @@
+#my-anchor-name-prop {
+  anchor-name: --my-anchor-name-prop;
+}
+
+#my-target-name-prop {
+  --anchor-var: --my-anchor-name-prop;
+
+  position: absolute;
+  right: anchor(var(--anchor-var) left);
+  bottom: anchor(var(--anchor-var) top);
+}

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -36,6 +36,7 @@ interface AnchorFunction {
   anchorName?: string;
   anchorEdge?: AnchorSide;
   fallbackValue: string;
+  customPropName?: string;
 }
 
 // `key` is the property being declared
@@ -127,11 +128,12 @@ export function isPercentage(
   return Boolean(node.type === 'Percentage' && node.value);
 }
 
-function parseAnchorFn(node: csstree.FunctionNode) {
+function parseAnchorFn(node: csstree.FunctionNode): AnchorFunction {
   let anchorName: string | undefined,
     anchorEdge: AnchorSide | undefined,
     fallbackValue = '',
-    foundComma = false;
+    foundComma = false,
+    customPropName: string | undefined;
   node.children.toArray().forEach((child, idx) => {
     if (foundComma) {
       fallbackValue = `${fallbackValue}${csstree.generate(child)}`;
@@ -144,7 +146,12 @@ function parseAnchorFn(node: csstree.FunctionNode) {
     switch (idx) {
       case 0:
         if (isIdentifier(child)) {
+          // Store anchor name
           anchorName = child.name;
+        } else if (isVarFunction(child) && child.children.first) {
+          // Store CSS custom prop for anchor name
+          const name = (child.children.first as csstree.Identifier).name;
+          customPropName = name;
         }
         break;
       case 1:
@@ -161,6 +168,7 @@ function parseAnchorFn(node: csstree.FunctionNode) {
     anchorName,
     anchorEdge,
     fallbackValue: fallbackValue || '0px',
+    customPropName,
   };
 }
 
@@ -176,7 +184,7 @@ function getAnchorNameData(node: csstree.CssNode, rule?: csstree.Raw) {
   return {};
 }
 
-const customProperties: Record<string, AnchorFunction> = {};
+const customPropAssignments: Record<string, AnchorFunction> = {};
 
 function getAnchorFunctionData(
   node: csstree.CssNode,
@@ -186,7 +194,7 @@ function getAnchorFunctionData(
   if (isAnchorFunction(node) && rule?.value && declaration) {
     const data = parseAnchorFn(node);
     if (declaration.property.startsWith('--')) {
-      customProperties[declaration.property] = data;
+      customPropAssignments[declaration.property] = data;
       return;
     }
     if (isInset(declaration.property)) {
@@ -239,6 +247,22 @@ function getPositionFallbackRules(node: csstree.CssNode) {
   return {};
 }
 
+function getCSSPropertyValue(el: HTMLElement, prop: string) {
+  return getComputedStyle(el).getPropertyValue(prop);
+}
+
+const anchorNames: AnchorNames = {};
+
+function getAnchorEl(targetEl: HTMLElement | null, anchorObj: AnchorFunction) {
+  let anchorName = anchorObj.anchorName;
+  const customPropName = anchorObj.customPropName;
+  if (targetEl && !anchorName && customPropName) {
+    anchorName = getCSSPropertyValue(targetEl, customPropName);
+  }
+  const anchorSelectors = anchorName ? anchorNames[anchorName] ?? [] : [];
+  return validatedForPositioning(targetEl, anchorSelectors);
+}
+
 export function getAST(cssText: string) {
   const ast = csstree.parse(cssText, {
     parseAtrulePrelude: false,
@@ -250,7 +274,6 @@ export function getAST(cssText: string) {
 }
 
 export function parseCSS(css: string) {
-  const anchorNames: AnchorNames = {};
   const anchorFunctions: AnchorFunctionDeclarations = {};
   const fallbackNames: FallbackNames = {};
   const fallbacks: Fallbacks = {};
@@ -308,8 +331,10 @@ export function parseCSS(css: string) {
     }
   });
 
+  const hasCustomPropAssignments =
+    Object.values(customPropAssignments).length > 0;
   // Find where CSS custom properties are used
-  if (Object.values(customProperties).length > 0) {
+  if (hasCustomPropAssignments) {
     csstree.walk(ast, function (node) {
       const rule = this.rule?.prelude as csstree.Raw | undefined;
       if (
@@ -320,7 +345,7 @@ export function parseCSS(css: string) {
         isInset(this.declaration.property)
       ) {
         const name = (node.children.first as csstree.Identifier).name;
-        const anchorFnData = customProperties[name];
+        const anchorFnData = customPropAssignments[name];
         if (anchorFnData) {
           anchorFunctions[rule.value] = {
             ...anchorFunctions[rule.value],
@@ -343,11 +368,7 @@ export function parseCSS(css: string) {
       positionFallbacks.forEach((tryBlock) => {
         for (const [prop, value] of Object.entries(tryBlock)) {
           if (typeof value === 'object') {
-            const anchorName = (value as AnchorFunction).anchorName;
-            const anchorSelectors = anchorName
-              ? anchorNames[anchorName] ?? []
-              : [];
-            const anchorEl = validatedForPositioning(targetEl, anchorSelectors);
+            const anchorEl = getAnchorEl(targetEl, value as AnchorFunction);
             (tryBlock[prop] as AnchorFunction).anchorEl = anchorEl;
           }
         }
@@ -362,17 +383,15 @@ export function parseCSS(css: string) {
   for (const [targetSel, anchorFns] of Object.entries(anchorFunctions)) {
     const targetEl: HTMLElement | null = document.querySelector(targetSel);
     for (const [targetProperty, anchorObj] of Object.entries(anchorFns)) {
+      const anchorEl = getAnchorEl(targetEl, anchorObj);
       // Populate `anchorEl` for each `anchor()` fn
-      const anchorSelectors = anchorObj.anchorName
-        ? anchorNames[anchorObj.anchorName] ?? []
-        : [];
       validPositions[targetSel] = {
         ...validPositions[targetSel],
         declarations: {
           ...validPositions[targetSel]?.declarations,
           [targetProperty]: {
             ...anchorObj,
-            anchorEl: validatedForPositioning(targetEl, anchorSelectors),
+            anchorEl,
           },
         },
       };

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -248,7 +248,7 @@ function getPositionFallbackRules(node: csstree.CssNode) {
 }
 
 function getCSSPropertyValue(el: HTMLElement, prop: string) {
-  return getComputedStyle(el).getPropertyValue(prop);
+  return getComputedStyle(el).getPropertyValue(prop).trim();
 }
 
 const anchorNames: AnchorNames = {};

--- a/tests/unit/parse.test.ts
+++ b/tests/unit/parse.test.ts
@@ -60,6 +60,34 @@ describe('parseCSS', () => {
     expect(result).toEqual(expected);
   });
 
+  it('parses `anchor()` (name set via custom property)', () => {
+    document.body.innerHTML =
+      '<div id="my-target-name-prop" style="--anchor-var: --my-anchor-name-prop"></div>' +
+      '<div id="my-anchor-name-prop"></div>';
+    const css = getSampleCSS('anchor-name-custom-prop');
+    const result = parseCSS(css);
+    const expected = {
+      '#my-target-name-prop': {
+        declarations: {
+          right: {
+            customPropName: '--anchor-var',
+            anchorEl: document.getElementById('my-anchor-name-prop'),
+            anchorEdge: 'left',
+            fallbackValue: '0px',
+          },
+          bottom: {
+            anchorEdge: 'top',
+            anchorEl: document.getElementById('my-anchor-name-prop'),
+            customPropName: '--anchor-var',
+            fallbackValue: '0px',
+          },
+        },
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+
   // https://trello.com/c/yOP9vqxZ
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('parses `anchor()` function (custom property passed through)', () => {
@@ -80,6 +108,43 @@ describe('parseCSS', () => {
             anchorEdge: 50,
             anchorEl: document.getElementById('my-anchor-props'),
             anchorName: '--my-anchor-props',
+            fallbackValue: '0px',
+          },
+        },
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  // https://trello.com/c/UGEMTfVc
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('parses `anchor()` function (multiple duplicate custom properties)', () => {
+    document.body.innerHTML = '<div id="target"></div><div id="anchor"></div>';
+    const css = `
+      #anchor {
+        anchor-name: --anchor;
+      }
+
+      #target {
+        --center: anchor(--anchor 50%);
+
+        position: absolute;
+        top: var(--center);
+      }
+
+      #other {
+        --center: anchor(--anchor 100%);
+      }
+    `;
+    const result = parseCSS(css);
+    const expected = {
+      '#target': {
+        declarations: {
+          top: {
+            anchorEdge: 50,
+            anchorEl: document.getElementById('anchor'),
+            anchorName: '--anchor',
             fallbackValue: '0px',
           },
         },


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&1109)

Fixes #45.