### PR TITLE
Set positions via CSS custom properties instead of directly on target elements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
 }</pre
       >
     </section>
-    <!-- <section id="math-function" class="demo-item">
+    <section id="math-function" class="demo-item">
       <h2>
         <a href="#math-function" aria-hidden="true">🔗</a>
         Anchor() [used in math function]
@@ -407,8 +407,9 @@
         <div id="my-target-math" class="target">Target</div>
       </div>
       <p class="note">
-        With polyfill applied: Target's left edge is aligned with 100% of the width of
-        the Anchor. The top edge of the Target lines up with 100% of the height of the Anchor, minus 50px.
+        With polyfill applied: Target's left edge is aligned with 100% of the
+        width of the Anchor (i.e. the Anchor's right edge). The top edge of the
+        Target is 50px above the top edge of the Anchor.
       </p>
       <pre>
 #my-anchor-math {
@@ -421,8 +422,9 @@
   position: absolute;
   top: calc(var(--full-math) - 50px);
   left: var(--full-math);
-}</pre>
-    </section> -->
+}</pre
+      >
+    </section>
     <!-- <section id="anchor-size" class="demo-item">
       <h2>
         <a href="#anchor-size" aria-hidden="true">🔗</a>

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   "dependencies": {
     "@floating-ui/dom": "^1.0.4",
     "@types/css-tree": "^2.0.0",
-    "css-tree": "^2.2.1"
+    "css-tree": "^2.2.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.27.1",
@@ -103,7 +104,6 @@
     "stylelint-config-standard": "^29.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4",
-    "uuid": "^9.0.0",
     "vite": "^3.2.3",
     "vitest": "^0.25.1"
   },

--- a/public/demo.css
+++ b/public/demo.css
@@ -215,6 +215,7 @@ h2 [aria-hidden]:active {
   color: var(--gray-9);
   font-weight: bold;
   padding: 0.5em;
+  white-space: nowrap;
 }
 
 .anchor {

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -11,6 +11,7 @@ import {
 
 import { fetchCSS } from './fetch.js';
 import { type AnchorPositions, type AnchorSide, parseCSS } from './parse.js';
+import { transformCSS } from './transform.js';
 
 // DOM platform does not have async methods
 interface DomPlatform extends Platform {
@@ -156,6 +157,8 @@ export const getPixelValue = ({
 };
 
 export function position(rules: AnchorPositions) {
+  const root = document.documentElement;
+
   Object.entries(rules).forEach(([targetSel, position]) => {
     const target: HTMLElement | null = document.querySelector(targetSel);
 
@@ -180,7 +183,7 @@ export function position(rules: AnchorPositions) {
               anchorEdge: anchorValue.anchorEdge,
               fallback: anchorValue.fallbackValue,
             });
-            Object.assign(target.style, { [property]: resolved });
+            root.style.setProperty(anchorValue.key, resolved);
           });
         }
       },
@@ -193,14 +196,14 @@ export async function polyfill() {
   const styleData = await fetchCSS();
 
   // parse CSS
-  const rules = parseCSS(styleData.map(({ css }) => css).join('\n'));
+  const rules = parseCSS(styleData);
 
   if (Object.values(rules).length) {
+    // calculate position values
     position(rules);
 
     // update source code
-    // https://trello.com/c/f1L7Ti8m
-    // transformCSS(styleData);
+    transformCSS(styleData);
   }
 
   return rules;

--- a/tests/unit/fetch.test.ts
+++ b/tests/unit/fetch.test.ts
@@ -26,9 +26,9 @@ describe('fetch stylesheet', () => {
     const styleData = await fetchCSS();
 
     expect(styleData).toHaveLength(2);
-    expect(styleData[0].source).toBe(`${location.origin}/sample.css`);
+    expect(styleData[0].url?.toString()).toBe(`${location.origin}/sample.css`);
     expect(styleData[0].css).toEqual(css);
-    expect(styleData[1].source).toBe('style');
+    expect(styleData[1].url).toBeUndefined();
     expect(styleData[1].css.trim()).toBe('p { color: red; }');
   });
 });
@@ -85,8 +85,8 @@ describe('fetch inline styles', () => {
     const styleData = await fetchCSS();
 
     expect(styleData).toHaveLength(4);
-    expect(styleData[2].source).toBe('style');
-    expect(styleData[3].source).toBe('style');
+    expect(styleData[2].url).toBeUndefined();
+    expect(styleData[3].url).toBeUndefined();
     expect(styleData[2].css.trim()).toContain('[data-anchor-polyfill=');
     expect(styleData[2].css.trim()).toContain(
       'top: anchor(--my-anchor-in-line end)',

--- a/tests/unit/parse.test.ts
+++ b/tests/unit/parse.test.ts
@@ -1,9 +1,10 @@
+import { type StyleData } from '../../src/fetch.js';
 import { parseCSS } from '../../src/parse.js';
 import { getSampleCSS, sampleBaseCSS } from './../helpers.js';
 
 describe('parseCSS', () => {
   it('handles missing `@position-fallback` at-rule or `anchor()` fn', () => {
-    const result = parseCSS(sampleBaseCSS);
+    const result = parseCSS([{ css: sampleBaseCSS }] as StyleData[]);
 
     expect(result).toEqual({});
   });
@@ -16,7 +17,7 @@ describe('parseCSS', () => {
         top: anchor(--my-anchor bottom);
       }
     `;
-    const result = parseCSS(css);
+    const result = parseCSS([{ css }] as StyleData[]);
     const expected = {
       '#f1': {
         declarations: {
@@ -30,14 +31,14 @@ describe('parseCSS', () => {
       },
     };
 
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
   it('parses `anchor()` function (custom properties)', () => {
     document.body.innerHTML =
       '<div id="my-target"></div><div id="my-anchor"></div>';
     const css = getSampleCSS('anchor');
-    const result = parseCSS(css);
+    const result = parseCSS([{ css }] as StyleData[]);
     const expected = {
       '#my-target': {
         declarations: {
@@ -57,7 +58,7 @@ describe('parseCSS', () => {
       },
     };
 
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
   it('parses `anchor()` (name set via custom property)', () => {
@@ -65,7 +66,7 @@ describe('parseCSS', () => {
       '<div id="my-target-name-prop" style="--anchor-var: --my-anchor-name-prop"></div>' +
       '<div id="my-anchor-name-prop"></div>';
     const css = getSampleCSS('anchor-name-custom-prop');
-    const result = parseCSS(css);
+    const result = parseCSS([{ css }] as StyleData[]);
     const expected = {
       '#my-target-name-prop': {
         declarations: {
@@ -85,7 +86,7 @@ describe('parseCSS', () => {
       },
     };
 
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
   // https://trello.com/c/yOP9vqxZ
@@ -94,7 +95,7 @@ describe('parseCSS', () => {
     document.body.innerHTML =
       '<div id="my-target-props"></div><div id="my-anchor-props"></div>';
     const css = getSampleCSS('anchor-custom-props');
-    const result = parseCSS(css);
+    const result = parseCSS([{ css }] as StyleData[]);
     const expected = {
       '#my-target-props': {
         declarations: {
@@ -114,7 +115,7 @@ describe('parseCSS', () => {
       },
     };
 
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
   // https://trello.com/c/UGEMTfVc
@@ -137,7 +138,7 @@ describe('parseCSS', () => {
         --center: anchor(--anchor 100%);
       }
     `;
-    const result = parseCSS(css);
+    const result = parseCSS([{ css }] as StyleData[]);
     const expected = {
       '#target': {
         declarations: {
@@ -151,16 +152,14 @@ describe('parseCSS', () => {
       },
     };
 
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
-  // https://trello.com/c/YAl95oDi
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('parses `anchor()` function (math)', () => {
+  it('parses `anchor()` function (math)', () => {
     document.body.innerHTML =
       '<div id="my-target-math"></div><div id="my-anchor-math"></div>';
     const css = getSampleCSS('anchor-math');
-    const result = parseCSS(css);
+    const result = parseCSS([{ css }] as StyleData[]);
     const expected = {
       '#my-target-math': {
         declarations: {
@@ -171,7 +170,7 @@ describe('parseCSS', () => {
             fallbackValue: '0px',
           },
           top: {
-            anchorEdge: 50,
+            anchorEdge: 100,
             anchorEl: document.getElementById('my-anchor-math'),
             anchorName: '--my-anchor-math',
             fallbackValue: '0px',
@@ -180,7 +179,7 @@ describe('parseCSS', () => {
       },
     };
 
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
   it('parses `anchor()` function (positioning)', () => {
@@ -188,7 +187,7 @@ describe('parseCSS', () => {
       '<div id="my-target-positioning"></div><div id="my-anchor-positioning"></div>';
     const anchorEl = document.getElementById('my-anchor-positioning');
     const css = getSampleCSS('anchor-positioning');
-    const result = parseCSS(css);
+    const result = parseCSS([{ css }] as StyleData[]);
     const expected = {
       '#my-target-positioning': {
         declarations: {
@@ -208,7 +207,7 @@ describe('parseCSS', () => {
       },
     };
 
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
   it('parses `@position-fallback` strategy', () => {
@@ -216,7 +215,7 @@ describe('parseCSS', () => {
       '<div id="my-target-fallback"></div><div id="my-anchor-fallback"></div>';
     const anchorEl = document.getElementById('my-anchor-fallback');
     const css = getSampleCSS('position-fallback');
-    const result = parseCSS(css);
+    const result = parseCSS([{ css }] as StyleData[]);
     const expected = {
       '#my-target-fallback': {
         declarations: {
@@ -310,7 +309,7 @@ describe('parseCSS', () => {
       },
     };
 
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
   it('parses `@position-fallback` with unknown anchor name', () => {
@@ -328,7 +327,7 @@ describe('parseCSS', () => {
         }
       }
     `;
-    const result = parseCSS(css);
+    const result = parseCSS([{ css }] as StyleData[]);
     const expected = {
       '#my-target-fallback': {
         fallbacks: [
@@ -350,7 +349,7 @@ describe('parseCSS', () => {
       },
     };
 
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
   it('handles duplicate anchor-names', () => {
@@ -368,7 +367,7 @@ describe('parseCSS', () => {
         top: anchor(--my-anchor bottom);
       }
     `;
-    const result = parseCSS(css);
+    const result = parseCSS([{ css }] as StyleData[]);
     const expected = {
       '#f1': {
         declarations: {
@@ -382,7 +381,7 @@ describe('parseCSS', () => {
       },
     };
 
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
   it('handles invalid/missing `position-fallback`', () => {
@@ -392,9 +391,8 @@ describe('parseCSS', () => {
         position-fallback: --fallback;
       }
     `;
-    const result = parseCSS(css);
-    const expected = {};
+    const result = parseCSS([{ css }] as StyleData[]);
 
-    expect(result).toEqual(expected);
+    expect(result).toEqual({});
   });
 });

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -1,14 +1,44 @@
-import { removeAnchorCSS } from '../../src/transform.js';
-import { getSampleCSS } from '../helpers.js';
+import { transformCSS } from '../../src/transform.js';
 
-describe('removeAnchorCSS', () => {
+describe('transformCSS', () => {
+  beforeAll(() => {
+    global.URL.createObjectURL = vi.fn().mockReturnValue('/updated.css');
+  });
+
   it('parses and removes new anchor positioning CSS after transformation to JS', () => {
-    const css = getSampleCSS('position-fallback');
-    const result = removeAnchorCSS(css);
+    document.head.innerHTML = `
+      <link type="text/css" href="/sample.css"/>
+      <style>
+        p { color: red; }
+      </style>
+    `;
+    document.body.innerHTML = `
+      <div id="div" data-anchor-polyfill="key" style="color: red;" />
+      <div id="div2" data-anchor-polyfill="key2" style="color: red;" />
+    `;
+    const link = document.querySelector('link') as HTMLLinkElement;
+    const style = document.querySelector('style') as HTMLStyleElement;
+    const div = document.getElementById('div') as HTMLDivElement;
+    const div2 = document.getElementById('div2') as HTMLDivElement;
+    const styleData = [
+      { el: link, css: 'html { margin: 0; }', changed: true },
+      { el: style, css: 'html { padding: 0; }', changed: true },
+      {
+        el: div,
+        css: '[data-anchor-polyfill="key"]{color:blue;}',
+        changed: true,
+      },
+      {
+        el: div2,
+        css: '[data-anchor-polyfill="key2"]{color:blue;}',
+        changed: false,
+      },
+    ];
+    transformCSS(styleData);
 
-    expect(result).not.toBe(css);
-    expect(result).not.toContain('position-fallback');
-    expect(result).not.toContain('@position-fallback');
-    expect(result).not.toContain('@try');
+    expect(link.href).toContain('/updated.css');
+    expect(style.innerHTML).toBe('html { padding: 0; }');
+    expect(div.style.color).toBe('blue');
+    expect(div2.style.color).toBe('red');
   });
 });


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&1116)

## Description

Before, we were calculating positions and then setting them directly via `targetElement.style.setProperty(...)`. This isn't ideal for two reasons:

1. It ignores the cascade. What if the `anchor()` call from the stylesheet is overridden by a different set of styles?
2. It doesn't allow any math outside of the `anchor` function, e.g. `top: calc(anchor(--my-anchor 100%) - 50px);`.

With the changes in this PR, we are now replacing uses of `anchor()` with a unique generated CSS custom property directly in the stylesheet, and then after we calculate the position value we simply assign that pixel value to the relevant CSS custom property. This way we can allow CSS itself to handle the cascade, and any relevant math.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

View the demo and confirm that the examples still work (including the new "used in math function" example).

![Screen Shot 2022-11-16 at 4 30 08 PM](https://user-images.githubusercontent.com/552316/202298534-c3b7df84-72c9-4901-9ece-1776089f6783.jpg)
