### PR TITLE
Sticky header

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,11 @@
           rel="noopener noreferrer"
           >Draft Spec</a
         >
+        <div data-controls="apply-polyfill">
+          <button id="apply-polyfill" data-button="apply-polyfill" type="button">
+            Apply Polyfill
+          </button>
+        </div>
       </nav>
     </header>
     <section>
@@ -133,11 +138,6 @@
         </li>
       </ul>
     </section>
-    <div data-controls="apply-polyfill">
-      <button id="apply-polyfill" data-button="apply-polyfill" type="button">
-        Apply Polyfill
-      </button>
-    </div>
     <section id="anchor-positioning" class="demo-item">
       <h2>
         <a href="#anchor-positioning" aria-hidden="true">🔗</a> Anchor

--- a/public/demo.css
+++ b/public/demo.css
@@ -56,6 +56,8 @@ footer {
 }
 
 header {
+  position: sticky;
+  top: 0;
   border-block-end: thin dotted var(--text);
   display: grid;
   gap: 0.5em;
@@ -70,12 +72,6 @@ nav {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5em;
-}
-
-[data-controls='apply-polyfill'] {
-  grid-column: main;
-  margin: var(--size-7) 0;
-  padding-inline-start: 1em;
 }
 
 section {

--- a/tests/unit/parse.test.ts
+++ b/tests/unit/parse.test.ts
@@ -89,8 +89,7 @@ describe('parseCSS', () => {
   });
 
   // https://trello.com/c/yOP9vqxZ
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('parses `anchor()` function (custom property passed through)', () => {
+  it('parses `anchor()` function (custom property passed through)', () => {
     document.body.innerHTML =
       '<div id="my-target-props"></div><div id="my-anchor-props"></div>';
     const css = getSampleCSS('anchor-custom-props');

--- a/tests/unit/parse.test.ts
+++ b/tests/unit/parse.test.ts
@@ -89,7 +89,8 @@ describe('parseCSS', () => {
   });
 
   // https://trello.com/c/yOP9vqxZ
-  it('parses `anchor()` function (custom property passed through)', () => {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('parses `anchor()` function (custom property passed through)', () => {
     document.body.innerHTML =
       '<div id="my-target-props"></div><div id="my-anchor-props"></div>';
     const css = getSampleCSS('anchor-custom-props');


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

Header now sticky and button moved to the top; not sure if it should further to the right?


## Show me

<img width="1707" alt="Screenshot 2022-12-08 at 18 33 47" src="https://user-images.githubusercontent.com/3077443/206538269-3ddf815f-1e4e-479a-a050-c298aca09e9b.png">


# REMEMBER: Attach this PR to the Trello card
