### PR TITLE
Use env vars to disable WPT result builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  # If the $WPT_ONLY env var is set, only build branches that end with `--wpt-results`
+  ignore = "if [[ ! $WPT_ONLY || $BRANCH == *--wpt-results ]]; then exit 1; else exit 0; fi"


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&121)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
Use the `ignore` config to skip builds that don't end with `--wpt-results`. Since this repo is the source of both https://anchor-polyfill.netlify.app/ and https://anchor-position-wpt.netlify.app/, I also added support for a `WPT_ONLY` env var to disable the branch name matching. In the Netlify UI the variable exists only for the WPT site, so the main site continues building for all branches.


## Steps to test/reproduce
I think we'll need to merge into `main` so Netlify picks up `netlify.toml`, because this branch is still being built by the WPT site and failing 🤷‍♂️

**EDIT**: Actually, it looks like it's working. The [main site logs](https://app.netlify.com/sites/anchor-polyfill/deploys/639b83580b96530008f38ac7) say the command allowed the build, and the [WPT site logs](https://app.netlify.com/sites/anchor-position-wpt/deploys/639b8358c9ab0e000880f336) say the build was canceled. The Netlify GH bot also seems to reflect that in the automated comments. More importantly, the GH checks are passing 👍