### PR TITLE
Run WPTs against browserslist

### DIFF
--- a/.github/workflows/test-wpt.yml
+++ b/.github/workflows/test-wpt.yml
@@ -106,5 +106,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: >
           gh --repo ${{ github.repository }}
-          pr comment $SOURCE_BRANCH
-          --body "WPT report for this branch: https://$SOURCE_BRANCH-wpt-results--anchor-position-wpt.netlify.app"
+          pr comment ${{ github.event.pull_request.number }}
+          --body "WPT report for this branch: https://${{ github.head_ref }}-wpt-results--anchor-position-wpt.netlify.app"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@typescript-eslint/parser": "^5.46.0",
     "@vitest/coverage-istanbul": "^0.25.7",
     "async": "^3.2.4",
+    "browserslist": "^4.21.4",
     "browserstack-local": "^1.5.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,6 +617,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.46.0
     "@vitest/coverage-istanbul": ^0.25.7
     async: ^3.2.4
+    browserslist: ^4.21.4
     browserstack-local: ^1.5.1
     cross-env: ^7.0.3
     css-tree: ^2.3.0
@@ -1205,7 +1206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.21.3":
+"browserslist@npm:^4.21.3, browserslist@npm:^4.21.4":
   version: 4.21.4
   resolution: "browserslist@npm:4.21.4"
   dependencies:


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&221216)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
Use browserslist queries to get the latest version numbers for each browser. Removes the need to manually update the test file on every browser release (which happens every few weeks). The only exception is Safari, which has a much slower velocity and each version if tied to the underlying iOS/macOS version.


## Steps to test/reproduce
The [WPT report generated by this PR](https://wpt-browserslist-wpt-results--anchor-position-wpt.netlify.app/) includes the most recent browser versions. In contrast, the [main report](https://anchor-position-wpt.netlify.app/) is using some old, hard-coded versions.
