### PR TITLE
Test against check-layout-delay WPT branch

### DIFF
--- a/.github/workflows/test-wpt.yml
+++ b/.github/workflows/test-wpt.yml
@@ -13,8 +13,8 @@ env:
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
   WPT_MANIFEST: ${{ github.workspace }}/wpt/MANIFEST.json
-  WPT_REPO: web-platform-tests/wpt
-  WPT_REF: master
+  WPT_REPO: oddbird/wpt
+  WPT_REF: check-layout-delay
   SOURCE_REPO: ${{ github.repository }}
   SOURCE_COMMIT: ${{ github.sha }}
   SOURCE_BRANCH: ${{ github.ref_name }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import { polyfill } from './polyfill.js';
 
+// @ts-expect-error Used by the WPT test harness to delay test assertions
+// and give the polyfill time to apply changes
+window.CHECK_LAYOUT_DELAY_MS = 100;
+
 // apply polyfill
 if (document.readyState !== 'complete') {
   window.addEventListener('load', () => {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&0117)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description
Test against the [`check-layout-delay` branch of our WPT fork](https://github.com/oddbird/wpt/pull/1), which introduces a small delay before checking the layout to ensure the polyfill has time to apply changes.

## Steps to test/reproduce
I'm seeing new passsing tests for `anchor-position-inline-*.html`, `anchor-position-dynamic-*.html` and `anchor-position-multicol-001.html`. Compare the [main branch results](https://anchor-position-wpt.netlify.app/2023-01-16t19-25-40.295z) with the [new results](https://check-layout-delay-wpt-results--anchor-position-wpt.netlify.app/2023-01-17t22-34-26.869z).