### PR TITLE
Update Limitations to match current spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,15 @@ option can be set by setting the value of
 
 ## Limitations
 
-This polyfill doesn't (yet) support the following:
+This polyfill was implemented against an early version of the spec, and updates
+were paused to allow the syntax to solidify. Now that browsers are working on
+implementation, we would like to bring it up to date.
 
-- `position-try`, `position-try-options`, and `position-try-order` properties
+While this polyfill supports many basic use cases, it doesn't (yet) support the
+following:
+
+- The `@position-try` rule
+- The `position-try-options`, `position-try-order`, or `position-try` properties
 - `anchor-scope` property
 - `position-anchor` property
 - `inset-area` property

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This polyfill doesn't (yet) support the following:
 
 - `position-try`, `position-try-options`, and `position-try-order` properties
 - `anchor-scope` property
-- `position-anchor` property (currently available as `anchor-default`)
+- `position-anchor` property
 - `inset-area` property
 - `anchor-center` value for `justify-self`, `align-self`, `justify-items`, and
   `align-items` properties

--- a/README.md
+++ b/README.md
@@ -76,11 +76,16 @@ option can be set by setting the value of
 
 This polyfill doesn't (yet) support the following:
 
-- `anchor-default` property
-- `anchor-scroll` property
+- `position-try`, `position-try-options`, and `position-try-order` properties
+- `anchor-scope` property
+- `position-anchor` property (currently available as `anchor-default`)
+- `inset-area` property
+- `anchor-center` value for `justify-self`, `align-self`, `justify-items`, and
+  `align-items` properties
 - anchor functions with `implicit` anchor-element
-- automatic anchor positioning: anchor functions with `auto` or `auto-same`
+- automatic anchor positioning: anchor functions with `inside` or `outside`
   anchor-side
+- `anchor-name` property defining multiple anchor names
 - dynamically added/removed anchors or targets
 - anchors or targets in the shadow-dom
 - tracking the order of elements in the

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ This polyfill doesn't (yet) support the following:
 - automatic anchor positioning: anchor functions with `inside` or `outside`
   anchor-side
 - `anchor-name` property defining multiple anchor names
+- `position-visibility` property
 - dynamically added/removed anchors or targets
 - anchors or targets in the shadow-dom
 - tracking the order of elements in the

--- a/README.md
+++ b/README.md
@@ -130,4 +130,4 @@ and centered on your needs as a developer!
 We display sponsor logos and avatars
 on our [website](https://www.oddbird.net/polyfill/#open-source-sponsors).
 
-[Sponsor OddBird's OSS Work](https://opencollective.com/oddbird-open-source)
+[Sponsor OddBird's OSS Work](https://github.com/sponsors/oddbird)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ This polyfill doesn't (yet) support the following:
   whose offset-parent is inline with `clientHeight`/`clientWidth` of `0`
   (partial support -- does not account for possible scrollbar width)
 
+In addition, JS APIs like `CSSPositionTryRule` or `CSS.supports` will not be
+  polyfilled.
+
 ## Sponsor OddBird's OSS Work
 
 At OddBird, we love contributing to the languages & tools developers rely on.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This polyfill doesn't (yet) support the following:
   (partial support -- does not account for possible scrollbar width)
 
 In addition, JS APIs like `CSSPositionTryRule` or `CSS.supports` will not be
-  polyfilled.
+polyfilled.
 
 ## Sponsor OddBird's OSS Work
 

--- a/index.html
+++ b/index.html
@@ -682,7 +682,7 @@
         >.
       </p>
       <a
-        href="https://opencollective.com/oddbird-open-source"
+        href="https://github.com/sponsors/oddbird"
         target="_blank"
         rel="noopener noreferrer"
         >Sponsor OddBird's OSS Work</a

--- a/index.html
+++ b/index.html
@@ -174,6 +174,19 @@
           >.
         </li>
       </ul>
+      <p>
+        <strong>Note: </strong>This polyfill was implemented against an early
+        version of the spec, and updates were paused to allow the syntax to
+        solidify. Now that browsers are working on implementation, we would like
+        to bring it up to date, and welcome
+        <a
+          href="https://github.com/oddbird/css-anchor-positioning"
+          target="_blank"
+          rel="noopener noreferrer"
+          >code contributions</a
+        >
+        and <a href="#sponsor">financial support</a> to make that happen.
+      </p>
     </section>
     <section id="anchor-positioning" class="demo-item">
       <h2>
@@ -646,6 +659,29 @@
   right: anchor(--my-anchor-update right);
   top: anchor(--my-anchor-update bottom);
 }</code></pre>
+    </section>
+    <section id="sponsor">
+      <h2>Sponsor OddBird's OSS Work</h2>
+      <p>
+        At OddBird, we love contributing to the languages & tools developers
+        rely on. We're currently working on polyfills for new Popover & Anchor
+        Positioning functionality, as well as CSS specifications for functions,
+        mixins, and responsive typography. Help us keep this work sustainable
+        and centered on your needs as a developer! We display sponsor logos and
+        avatars on our
+        <a
+          href="https://www.oddbird.net/polyfill/#open-source-sponsors"
+          target="_blank"
+          rel="noopener noreferrer"
+          >website</a
+        >.
+      </p>
+      <a
+        href="https://opencollective.com/oddbird-open-source"
+        target="_blank"
+        rel="noopener noreferrer"
+        >Sponsor OddBird's OSS Work</a
+      >
     </section>
     <footer>
       <p>

--- a/index.html
+++ b/index.html
@@ -388,6 +388,11 @@
       </div>
       <div class="note">
         <p>
+          <strong>Note: </strong>The <code>@position-fallback</code> syntax has
+          been replaced in the spec, and will be deprecated in the next version
+          of this Polyfill.
+        </p>
+        <p>
           With polyfill applied, the following positions are attempted in order:
         </p>
         <ol>


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&limitations)

## Description
1. Updates the Limitations section in README against the spec as of March. https://www.w3.org/TR/css-anchor-position-1
2. Adds Status note to [Demo](https://deploy-preview-177--anchor-polyfill.netlify.app/), and deprecation notice on `@position-fallback` example.