### PR TITLE
Remove unneeded Polyfill

### DIFF
--- a/tests/runner.html
+++ b/tests/runner.html
@@ -1,8 +1,5 @@
 <!doctype html>
 <html>
-  <head>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=Promise"></script>
-  </head>
   <body>
     <style>
       .test-harness {


### PR DESCRIPTION
## Description
Removes CDN import from polyfill.io, which is no longer recommended.

I don't think we need a Promise Polyfill anymore, but if we do, we have options from https://community.fastly.com/t/new-options-for-polyfill-io-users/2540.