### PR TITLE
Pseudo-element anchors

### DIFF
--- a/index.html
+++ b/index.html
@@ -781,18 +781,20 @@
         <div id="my-target-pseudo-element" class="target">Target</div>
       </div>
       <p class="note">
-        Target is positioned at the bottom right corner of the Anchor.
+        Target is positioned at the bottom right corner of the Anchor's
+        <code>::before</code> pseudo-element.
       </p>
       <pre><code class="language-css"
 >#my-anchor-pseudo-element::before {
-  content: '';
+  content: '::before';
   anchor-name: --my-anchor-pseudo-element;
 }
 
 #my-target-pseudo-element {
   position: absolute;
-  top: anchor(--my-anchor-pseudo-element bottom);
-  left: anchor(--my-anchor-pseudo-element right);
+  position-anchor: --my-anchor-pseudo-element;
+  top: anchor(bottom);
+  left: anchor(right);
 }</code></pre>
     </section>
     <section id="sponsor">

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
     <link rel="stylesheet" href="/anchor-implicit.css" />
     <link rel="stylesheet" href="/anchor-update.css" />
     <link rel="stylesheet" href="/anchor-absolute.css" />
+    <link rel="stylesheet" href="/anchor-pseudo-element.css" />
     <style>
       #my-anchor-style-tag {
         anchor-name: --my-anchor-style-tag;
@@ -773,6 +774,30 @@
   position: absolute;
   top: anchor(--my-anchor-absolute bottom);
   left: anchor(--my-anchor-absolute right);
+}</code></pre>
+    </section>
+    <section id="anchor-pseudo-element" class="demo-item">
+      <h2>
+        <a href="#anchor-pseudo-element" aria-hidden="true">🔗</a>
+        Pseudo-element anchor
+      </h2>
+      <div style="position: relative" class="demo-elements">
+        <div id="my-anchor-pseudo-element" class="anchor">Anchor</div>
+        <div id="my-target-pseudo-element" class="target">Target</div>
+      </div>
+      <p class="note">
+        Target is positioned at the bottom right corner of the Anchor.
+      </p>
+      <pre><code class="language-css"
+>#my-anchor-pseudo-element::before {
+  content: '';
+  anchor-name: --my-anchor-pseudo-element;
+}
+
+#my-target-pseudo-element {
+  position: absolute;
+  top: anchor(--my-anchor-pseudo-element bottom);
+  left: anchor(--my-anchor-pseudo-element right);
 }</code></pre>
     </section>
     <section id="sponsor">

--- a/public/anchor-pseudo-element.css
+++ b/public/anchor-pseudo-element.css
@@ -1,12 +1,13 @@
 #my-anchor-pseudo-element::before {
   content: '::before';
   margin-right: 1ch;
-  background-color: white;
+  background-color: var(--pseudo-element);
   anchor-name: --my-anchor-pseudo-element;
 }
 
 #my-target-pseudo-element {
   position: absolute;
-  top: anchor(--my-anchor-pseudo-element bottom);
-  left: anchor(--my-anchor-pseudo-element right);
+  position-anchor: --my-anchor-pseudo-element;
+  top: anchor(bottom);
+  left: anchor(right);
 }

--- a/public/anchor-pseudo-element.css
+++ b/public/anchor-pseudo-element.css
@@ -1,9 +1,7 @@
 #my-anchor-pseudo-element::before {
   content: '::before';
-
   margin-right: 1ch;
   background-color: white;
-
   anchor-name: --my-anchor-pseudo-element;
 }
 

--- a/public/anchor-pseudo-element.css
+++ b/public/anchor-pseudo-element.css
@@ -1,0 +1,14 @@
+#my-anchor-pseudo-element::before {
+  content: '::before';
+
+  margin-right: 1ch;
+  background-color: white;
+
+  anchor-name: --my-anchor-pseudo-element;
+}
+
+#my-target-pseudo-element {
+  position: absolute;
+  top: anchor(--my-anchor-pseudo-element bottom);
+  left: anchor(--my-anchor-pseudo-element right);
+}

--- a/public/demo.css
+++ b/public/demo.css
@@ -21,6 +21,7 @@ html {
   --text: var(--gray-9);
   --note-color: var(--target);
   --page-margin: calc(var(--size-3) + 4vw);
+  --pseudo-element: var(--gray-0);
 
   background-color: var(--bg);
   color: var(--text);

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -429,7 +429,7 @@ function getAnchorFunctionData(
 
 function getPositionFallbackDeclaration(
   node: csstree.Declaration,
-  selectorList?: csstree.SelectorList,
+  selectorList: csstree.SelectorList | undefined,
 ) {
   if (
     isFallbackDeclaration(node) &&
@@ -546,13 +546,10 @@ export async function parseCSS(styleData: StyleData[]) {
         const selectors = getSelectors(rule);
 
         // Parse `position-fallback` declaration
-        const { name } = getPositionFallbackDeclaration(node);
+        const { name } = getPositionFallbackDeclaration(node, rule);
         if (name && selectors.length && fallbacks[name]) {
-          const selectorList = selectors
-            .map(({ selector }) => selector)
-            .join(', ');
-
           for (const { selector } of selectors) {
+            validPositions[selector] = { fallbacks: fallbacks[name].blocks };
             if (!fallbacks[name].targets.includes(selector)) {
               fallbacks[name].targets.push(selector);
             }
@@ -583,7 +580,9 @@ export async function parseCSS(styleData: StyleData[]) {
               },
             });
             // Store mapping of data-attr to target selector
-            fallbackTargets[dataAttr] = selectorList;
+            for (const { selector } of selectors) {
+              fallbackTargets[dataAttr] = selector;
+            }
           }
           changed = true;
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,6 @@ export interface DeclarationWithValue extends csstree.Declaration {
 export function getAST(cssText: string) {
   return csstree.parse(cssText, {
     parseAtrulePrelude: false,
-    parseRulePrelude: false,
     parseCustomProperty: true,
   });
 }


### PR DESCRIPTION
TODO:
- [x] Fix the "Positioning with anchor() [passed through multiple CSS custom properties]" example. `customPropsMapping` seems not to get populated.
- [x] Update tests to expect pseudo elements.
- [ ] Get WPT passing for pseudo-element anchors. The polyfill is working (if I manually check the conditions, eg. `anchored1.offsetTop === 100`) but WPT reports `0`, no tests went down.

~Performance does not seem worse (tested with `console.time` consistently at \~110ms).~

Closes #208.