### PR TITLE
Fix pseudo-element anchors with `overflow: scroll;` parents

### DIFF
--- a/index.html
+++ b/index.html
@@ -777,7 +777,13 @@
         Pseudo-element anchor
       </h2>
       <div style="position: relative" class="demo-elements">
-        <div id="my-anchor-pseudo-element" class="anchor">Anchor</div>
+        <div class="scroll-container">
+          <div class="placefiller-above-anchor"></div>
+          <div class="placefiller-before-anchor"></div>
+          <span id="my-anchor-pseudo-element" class="anchor">Anchor</span>
+          <div class="placefiller-after-anchor"></div>
+        </div>
+
         <div id="my-target-pseudo-element" class="target">Target</div>
       </div>
       <p class="note">


### PR DESCRIPTION
I started to write the issue but then it felt simpler to fix it :)

The only thing I'm not sure about is the demo, I changed it for this case but now there isn't one without scrolling, having both maybe gets too long?