### PR TITLE
Fix #242: keep id,media,title attributes on replaced link elements

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -12,13 +12,16 @@ export async function transformCSS(
       if (el.tagName.toLowerCase() === 'style') {
         // Handle inline stylesheets
         el.innerHTML = css;
-      } else if (el.tagName.toLowerCase() === 'link') {
+      } else if (el instanceof HTMLLinkElement) {
         // Create new link
         const blob = new Blob([css], { type: 'text/css' });
         const url = URL.createObjectURL(blob);
         const link = document.createElement('link');
         link.rel = 'stylesheet';
         link.href = url;
+        link.id = el.id;
+        link.media = el.media;
+        link.title = el.title;
         const promise = new Promise((res) => {
           link.onload = res;
         });

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -49,4 +49,24 @@ describe('transformCSS', () => {
     expect(div.hasAttribute('data-has-inline-styles')).toBeFalsy();
     expect(div2.hasAttribute('data-has-inline-styles')).toBeFalsy();
   });
+
+  it('preserves id, media, and title attributes when replacing link elements', async () => {
+    document.head.innerHTML = `
+      <link id="the-link" media="screen" title="stylish" rel="stylesheet" href="/sample.css"/>
+    `;
+    let link = document.querySelector('link') as HTMLLinkElement;
+    const styleData = [
+      { el: link, css: 'html { margin: 0; }', changed: true },
+    ];
+    const inlineStyles = new Map();
+    const promise = transformCSS(styleData, inlineStyles, true);
+    link = document.querySelector('link') as HTMLLinkElement;
+    link.dispatchEvent(new Event('load'));
+    await promise;
+
+    expect(link.href).toContain('/updated.css');
+    expect(link.id).toBe('the-link');
+    expect(link.media).toBe('screen');
+    expect(link.title).toBe('stylish');
+  });
 });

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -55,9 +55,7 @@ describe('transformCSS', () => {
       <link id="the-link" media="screen" title="stylish" rel="stylesheet" href="/sample.css"/>
     `;
     let link = document.querySelector('link') as HTMLLinkElement;
-    const styleData = [
-      { el: link, css: 'html { margin: 0; }', changed: true },
-    ];
+    const styleData = [{ el: link, css: 'html { margin: 0; }', changed: true }];
     const inlineStyles = new Map();
     const promise = transformCSS(styleData, inlineStyles, true);
     link = document.querySelector('link') as HTMLLinkElement;


### PR DESCRIPTION
I could not get the test to work with the `disabled` attribute (`jsdom` does not implement that attribute) so I just left it out.