### PR TITLE
Fallbacks: flip anchor functions that are nested in other function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ following features:
   - The `flip-start` `try-tactic` is only partially supported. The tactic is
     only applied to property names and anchor sides.
   - a `position-area` as a `try-tactic`
-  - Fallback does does not support anchor functions that are nested or passed
-    through custom properties.
+  - Fallback does not support percentage anchor-side values, nor anchor
+    functions that are passed through custom properties.
 - Polyfill allows anchoring in scroll more permissively than the spec allows,
   for instance without a default `position-anchor`.
 - `anchor-scope` property on pseudo-elements

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -24,6 +24,7 @@ import {
   getAST,
   getSelectors,
   INSTANCE_UUID,
+  isAnchorFunction,
   splitCommaList,
   type StyleData,
 } from './utils.js';
@@ -420,11 +421,12 @@ export function applyTryTacticToBlock(
       declarations[key] ??= 'revert';
     }
 
-    // todo: This does not support anchor functions that are passed through custom properties.
+    // todo: This does not support percentage anchor-side values, nor anchor
+    // functions that are passed through custom properties.
     csstree.walk(valueAst, {
       visit: 'Function',
       enter(node) {
-        if (node.name === 'anchor') {
+        if (isAnchorFunction(node)) {
           node.children.forEach((item) => {
             if (isIdentifier(item) && isAnchorSide(item.name)) {
               item.name = mapAnchorSide(item.name, tactic);

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -24,7 +24,6 @@ import {
   getAST,
   getSelectors,
   INSTANCE_UUID,
-  isAnchorFunction,
   splitCommaList,
   type StyleData,
 } from './utils.js';
@@ -421,15 +420,19 @@ export function applyTryTacticToBlock(
       declarations[key] ??= 'revert';
     }
 
-    // todo: This does not support anchor functions that are nested or passed
-    // through custom properties.
-    if (isAnchorFunction(valueAst.children.first)) {
-      valueAst.children.first.children.forEach((item) => {
-        if (isIdentifier(item) && isAnchorSide(item.name)) {
-          item.name = mapAnchorSide(item.name, tactic);
+    // todo: This does not support anchor functions that are passed through custom properties.
+    csstree.walk(valueAst, {
+      visit: 'Function',
+      enter(node) {
+        if (node.name === 'anchor') {
+          node.children.forEach((item) => {
+            if (isIdentifier(item) && isAnchorSide(item.name)) {
+              item.name = mapAnchorSide(item.name, tactic);
+            }
+          });
         }
-      });
-    }
+      }
+    });
 
     if (key === 'position-area') {
       valueAst.children.forEach((id) => {

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -431,7 +431,7 @@ export function applyTryTacticToBlock(
             }
           });
         }
-      }
+      },
     });
 
     if (key === 'position-area') {

--- a/tests/unit/fallback.test.ts
+++ b/tests/unit/fallback.test.ts
@@ -48,6 +48,14 @@ describe('fallback', () => {
           },
         ],
         [
+          'flips anchor functions that are nested',
+          `${propWrap('bottom')}: calc(anchor(top) + 5px);${propWrap('top')}:calc(calc(anchor(--a top) + 5px) - 0.5em)`,
+          {
+            top: 'calc(anchor(bottom) + 5px)',
+            bottom: 'calc(calc(anchor(--a bottom) + 5px) - 0.5em)',
+          },
+        ],
+        [
           'does not flip left and right anchors',
           `${propWrap('left')}: anchor(right);${propWrap('right')}:anchor(--a left)`,
           {
@@ -145,6 +153,14 @@ describe('fallback', () => {
           {
             left: 'anchor(self-end)',
             right: 'anchor(self-start)',
+          },
+        ],
+        [
+          'flips anchor functions that are nested',
+          `${propWrap('right')}: calc(anchor(left) + 5px);${propWrap('left')}:calc(calc(anchor(--a left) + 5px) - 0.5em)`,
+          {
+            left: 'calc(anchor(right) + 5px)',
+            right: 'calc(calc(anchor(--a right) + 5px) - 0.5em)',
           },
         ],
         [


### PR DESCRIPTION
Not aware of an existing open issue for this, but I encountered it today.
