### PR TITLE
Allow polyfilling imperatively for a single style element

### DIFF
--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -26,7 +26,6 @@ import {
   type SizingProperty,
 } from './syntax.js';
 import { transformCSS } from './transform.js';
-import type { StyleData } from './utils.js';
 
 const platformWithCache = { ...platform, _c: new Map() };
 

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -26,6 +26,7 @@ import {
   type SizingProperty,
 } from './syntax.js';
 import { transformCSS } from './transform.js';
+import type { StyleData } from './utils.js';
 
 const platformWithCache = { ...platform, _c: new Map() };
 
@@ -443,13 +444,14 @@ async function position(rules: AnchorPositions, useAnimationFrame = false) {
   }
 }
 
-export async function polyfill(animationFrame?: boolean) {
+export async function polyfill(animationFrame?: boolean, el?: HTMLStyleElement) {
   const useAnimationFrame =
     animationFrame === undefined
       ? Boolean(window.UPDATE_ANCHOR_ON_ANIMATION_FRAME)
       : animationFrame;
+
   // fetch CSS from stylesheet and inline style
-  let styleData = await fetchCSS();
+  let styleData = el ? [{el, css: el.textContent ?? ''}] : await fetchCSS();
 
   // pre parse CSS styles that we need to cascade
   const cascadeCausedChanges = await cascadeCSS(styleData);


### PR DESCRIPTION
## Description

This change provides an alternative way for authors to apply polyfill: instead of letting the polyfill to lookup stylesheets and 
apply the polyfill, the second argument takes a `<style>` element and the function can apply polyfill based on its content.

This is particularly useful for components like custom elements, as often the stylesheets are added dynamically to the document, and the currently "auto" polyfilling makes it challenging to apply the changes at the right time.

## Related Issue(s)

https://github.com/oddbird/css-anchor-positioning/issues/228
