### PR TITLE
Replace the <link> without flashing the css

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -25,9 +25,10 @@ export async function transformCSS(
         const promise = new Promise((res) => {
           link.onload = res;
         });
-        el.replaceWith(link);
+        el.insertAdjacentElement('afterend', link);
         // Wait for new stylesheet to be loaded
         await promise;
+        el.remove();
         URL.revokeObjectURL(url);
         updatedObject.el = link;
       } else if (el.hasAttribute('data-has-inline-styles')) {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -25,7 +25,7 @@ export async function transformCSS(
         const promise = new Promise((res) => {
           link.onload = res;
         });
-        el.insertAdjacentElement('afterend', link);
+        el.insertAdjacentElement('beforebegin', link);
         // Wait for new stylesheet to be loaded
         await promise;
         el.remove();


### PR DESCRIPTION
This fixes the flash of unstyled content (FOUC) by inserting the new stylesheet before the old one is removed.