### PR TITLE
Warn if mime type is not CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
       defer
     ></script>
     <link rel="stylesheet" href="/demo.css" />
+    <!-- Included to test invalid  -->
+    <link rel="stylesheet" href="/fake.css" />
     <link rel="stylesheet" href="/anchor.css" />
     <link rel="stylesheet" href="/anchor-positioning.css" />
     <link rel="stylesheet" href="/anchor-popover.css" />

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       defer
     ></script>
     <link rel="stylesheet" href="/demo.css" />
-    <!-- Included to test invalid  -->
+    <!-- Included to test invalid stylesheets -->
     <link rel="stylesheet" href="/fake.css" />
     <link rel="stylesheet" href="/anchor.css" />
     <link rel="stylesheet" href="/anchor-positioning.css" />

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -29,7 +29,7 @@ async function fetchLinkedStylesheets(
       try {
         const response = await fetch(data.url.toString());
         const type = response.headers.get('content-type');
-        if (type !== 'text/css') {
+        if (!type?.startsWith('text/css')) {
           const error = new Error(
             `Error loading ${data.url}: expected content-type "text/css", got "${type}".`,
           );

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -25,3 +25,8 @@ export function cascadeCSSForTest(css: string) {
   cascadeCSS([styleObj]);
   return styleObj.css;
 }
+
+export const requestWithCSSType = (css: string) => ({
+  body: css,
+  headers: { 'Content-Type': 'text/css' },
+});

--- a/tests/unit/fetch.test.ts
+++ b/tests/unit/fetch.test.ts
@@ -1,7 +1,7 @@
 import fetchMock from 'fetch-mock';
 
 import { fetchCSS } from '../../src/fetch.js';
-import { getSampleCSS } from '../helpers.js';
+import { getSampleCSS, requestWithCSSType } from '../helpers.js';
 
 describe('fetch stylesheet', () => {
   beforeAll(() => {
@@ -22,7 +22,7 @@ describe('fetch stylesheet', () => {
 
   it('fetches CSS', async () => {
     const css = getSampleCSS('anchor-positioning');
-    fetchMock.getOnce('end:sample.css', css);
+    fetchMock.getOnce('end:sample.css', requestWithCSSType(css));
     const styleData = await fetchCSS();
 
     expect(styleData).toHaveLength(2);
@@ -81,7 +81,7 @@ describe('fetch inline styles', () => {
 
   it('fetch returns inline CSS', async () => {
     const css = getSampleCSS('anchor-positioning');
-    fetchMock.getOnce('end:sample.css', css);
+    fetchMock.getOnce('end:sample.css', requestWithCSSType(css));
     const styleData = await fetchCSS();
 
     expect(styleData).toHaveLength(4);


### PR DESCRIPTION
## Description
If a `<link>` fails to load, we should recover gracefully. This may be because it's a 404 or because it's being loaded as CSS-in-JS for HMR. It possibly is due to a misconfigured server. Ideally we would confirm if it's actually CSS instead of just relying on mimetype, but there's not a good way of checking that.

## Related Issue(s)
#255


## Steps to test/reproduce

- Load the demo in a polyfilled browser, see that `fake.css` fails to load initially. 
- Apply the polyfill.
- See that the polyfill applies successfully
- A console warning shows what the error is


## Show me
https://deploy-preview-258--anchor-polyfill.netlify.app/
