### PR TITLE
Do not revoke object URL of polyfilled styles

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -29,7 +29,6 @@ export async function transformCSS(
         // Wait for new stylesheet to be loaded
         await promise;
         el.remove();
-        URL.revokeObjectURL(url);
         updatedObject.el = link;
       } else if (el.hasAttribute('data-has-inline-styles')) {
         // Handle inline styles

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -3,7 +3,6 @@ import { transformCSS } from '../../src/transform.js';
 describe('transformCSS', () => {
   beforeAll(() => {
     global.URL.createObjectURL = vi.fn().mockReturnValue('/updated.css');
-    global.URL.revokeObjectURL = vi.fn();
   });
 
   it('parses and removes new anchor positioning CSS after transformation to JS', async () => {


### PR DESCRIPTION
## Description

After loading the polyfilled styles, we were calling [`revokeObjectURL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static) to release the URL. If the polyfill is applied again, this caused an error when trying to fetch the already-polyfilled styles from the blob URL.

## Related Issue(s)

#253 

## Steps to test/reproduce

- Open in Firefox
- Click the "Polyfill these elements" manual button
- Click the global "Apply Polyfill" button
- No error is thrown