### PR TITLE
Add note about implicit support

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,6 +435,12 @@
       <p class="note">
         With polyfill applied: Target is positioned at the top left corner of
         the Anchor.
+        <br />
+        <br />
+        <strong>Note:</strong> The <code>anchor</code> attribute has not yet
+        been standardized, and currently does not work in non-polyfilled
+        browsers. See more conversation <a
+        href="https://github.com/whatwg/html/pull/9144">here</a>.
       </p>
       <pre><code class="language-html"
 >&lt;div id="my-implicit-anchor"&gt;Anchor&lt;/div&gt;


### PR DESCRIPTION
The `anchor` attribute has been removed from the standard pending conversation here- https://github.com/whatwg/html/pull/9144. Alternatively, we could remove this feature until it is supported, but I'm not sure it's worth it.