### PR TITLE
Reduce built library size

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,7 @@
       }
     </style>
     <script type="module">
-      // Todo: Switch back to loading from /src/index-fn.ts
-      import polyfill from '/dist/css-anchor-positioning-fn.js'
+      import polyfill from '/src/index-fn.ts';
 
       const SUPPORTS_ANCHOR_POSITIONING =
         'anchorName' in document.documentElement.style;

--- a/index.html
+++ b/index.html
@@ -61,7 +61,8 @@
       }
     </style>
     <script type="module">
-      import polyfill from '/src/index-fn.ts';
+      // Todo: Switch back to loading from /src/index-fn.ts
+      import polyfill from '/dist/css-anchor-positioning-fn.js'
 
       const SUPPORTS_ANCHOR_POSITIONING =
         'anchorName' in document.documentElement.style;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "@floating-ui/dom": "^1.6.12",
         "@types/css-tree": "^2.3.8",
         "css-tree": "^3.0.0",
-        "nanoid": "^5.0.8",
-        "rollup-plugin-bundle-stats": "^4.17.0"
+        "nanoid": "^5.0.8"
       },
       "devDependencies": {
         "@playwright/test": "1.43.1",
@@ -37,6 +36,7 @@
         "node-fetch": "^2.6.7",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.3.3",
+        "rollup-plugin-bundle-stats": "^4.17.0",
         "selenium-webdriver": "^4.26.0",
         "stylelint": "^16.10.0",
         "stylelint-config-standard": "^36.0.1",
@@ -411,6 +411,7 @@
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/@bundle-stats/cli-utils/-/cli-utils-4.17.0.tgz",
       "integrity": "sha512-JIQBOda71sEyDOfJ0/YIIatwVnEB8UsbyFmHbTZXMqVhPU7ddnRzmYmPgmnqPkhqss3tjArTHGS+HIL9Kvs7Cw==",
+      "dev": true,
       "dependencies": {
         "@bundle-stats/html-templates": "^4.17.0",
         "@bundle-stats/plugin-webpack-filter": "^4.17.0",
@@ -427,12 +428,14 @@
     "node_modules/@bundle-stats/html-templates": {
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/@bundle-stats/html-templates/-/html-templates-4.17.0.tgz",
-      "integrity": "sha512-B9AYHV1hyioS8S5qpWmP7vEn1npBWJHV/tSEHRFQTJOpGZdn6L0jHyzvofRvopqirTff++UpVS3TelN+Elh/tQ=="
+      "integrity": "sha512-B9AYHV1hyioS8S5qpWmP7vEn1npBWJHV/tSEHRFQTJOpGZdn6L0jHyzvofRvopqirTff++UpVS3TelN+Elh/tQ==",
+      "dev": true
     },
     "node_modules/@bundle-stats/plugin-webpack-filter": {
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/@bundle-stats/plugin-webpack-filter/-/plugin-webpack-filter-4.17.0.tgz",
       "integrity": "sha512-sGC1c7oiRNKY19OLNB2Yha88Yt+UC7OJWlk8O6HBvN/OO8ACvZ6DuxRMNBXMyP0cDDAJlcY9v9rzy0bbnegzAw==",
+      "dev": true,
       "engines": {
         "node": ">= 14.0"
       },
@@ -444,6 +447,7 @@
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/@bundle-stats/plugin-webpack-validate/-/plugin-webpack-validate-4.17.0.tgz",
       "integrity": "sha512-dsCAIYiQ1ohRt7wyR5gfQCT3OKLjHxRZ3F/uL0gnBO56+xnvDzO/s+A5QO4EerlXIRIUBW8JWWuYAhe8ccdFjA==",
+      "dev": true,
       "dependencies": {
         "lodash": "4.17.21",
         "superstruct": "2.0.2"
@@ -456,6 +460,7 @@
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/@bundle-stats/utils/-/utils-4.17.0.tgz",
       "integrity": "sha512-0/8/hebdV7QzPBZW7uyKClWpSsxVsQ/DfDwmNkmXSOq45eTeVNXozyvdYgwmLz0Ff9tVMyXu0Kb6iAVL6Hpt+g==",
+      "dev": true,
       "dependencies": {
         "@bundle-stats/plugin-webpack-filter": "^4.17.0",
         "@bundle-stats/plugin-webpack-validate": "^4.17.0",
@@ -1369,6 +1374,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1381,6 +1387,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1393,6 +1400,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1405,6 +1413,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1417,6 +1426,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1429,6 +1439,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1441,6 +1452,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1453,6 +1465,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1465,6 +1478,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1477,6 +1491,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1489,6 +1504,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1501,6 +1517,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1513,6 +1530,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1525,6 +1543,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1537,6 +1556,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1549,6 +1569,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1598,7 +1619,8 @@
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
     },
     "node_modules/@types/glob-to-regexp": {
       "version": "0.4.4",
@@ -2461,7 +2483,8 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2479,6 +2502,7 @@
       "version": "3.39.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
       "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
+      "dev": true,
       "hasInstallScript": true,
       "peer": true,
       "funding": {
@@ -3589,6 +3613,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
       "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -3605,6 +3630,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -3619,6 +3645,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3713,6 +3740,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -4884,7 +4912,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5524,6 +5553,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5581,6 +5611,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5710,6 +5741,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -5721,6 +5753,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -5733,6 +5766,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -5744,6 +5778,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -5758,6 +5793,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -6108,6 +6144,7 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
       "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
+      "dev": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -6142,6 +6179,7 @@
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-bundle-stats/-/rollup-plugin-bundle-stats-4.17.0.tgz",
       "integrity": "sha512-qib0al0arhVlF1/nXynKNXbE5uUWuGr0GNzs+Dpub8Wu2bEvb3m5WaMpotXrK8d4pYoBpC8v38fXSqH0H+tapA==",
+      "dev": true,
       "dependencies": {
         "@bundle-stats/cli-utils": "^4.17.0",
         "rollup-plugin-webpack-stats": "0.4.1"
@@ -6157,6 +6195,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-webpack-stats/-/rollup-plugin-webpack-stats-0.4.1.tgz",
       "integrity": "sha512-Zi7t0G7FtA55LNcU9B3s2gBo3PODbdo+288Cw2/4sA8+o9H/ahhWZ25UxADeHwriAzW808iDpPbB81C5jGLIbg==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -6282,7 +6321,8 @@
     "node_modules/serialize-query-params": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.2.tgz",
-      "integrity": "sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q=="
+      "integrity": "sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==",
+      "dev": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -6482,6 +6522,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-3.3.2.tgz",
       "integrity": "sha512-YvRznt2X9tLSQlQXkYxp9FGcp6uUwBG9VAyjgo53Ov+Ctk36R49xB6NUia37T7owHyi3UtvI6achAj4ufBSaNg==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/uhop"
       }
@@ -6499,6 +6540,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
       "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "dev": true,
       "dependencies": {
         "stream-chain": "^2.2.5"
       }
@@ -6506,7 +6548,8 @@
     "node_modules/stream-json/node_modules/stream-chain": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
-      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -6821,6 +6864,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
       "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@floating-ui/dom": "^1.6.12",
         "@types/css-tree": "^2.3.8",
         "css-tree": "^3.0.0",
-        "nanoid": "^5.0.8"
+        "nanoid": "^5.0.8",
+        "rollup-plugin-bundle-stats": "^4.17.0"
       },
       "devDependencies": {
         "@playwright/test": "1.43.1",
@@ -405,6 +406,68 @@
       "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.3.1.tgz",
       "integrity": "sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==",
       "dev": true
+    },
+    "node_modules/@bundle-stats/cli-utils": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@bundle-stats/cli-utils/-/cli-utils-4.17.0.tgz",
+      "integrity": "sha512-JIQBOda71sEyDOfJ0/YIIatwVnEB8UsbyFmHbTZXMqVhPU7ddnRzmYmPgmnqPkhqss3tjArTHGS+HIL9Kvs7Cw==",
+      "dependencies": {
+        "@bundle-stats/html-templates": "^4.17.0",
+        "@bundle-stats/plugin-webpack-filter": "^4.17.0",
+        "@bundle-stats/utils": "^4.17.0",
+        "find-cache-dir": "^3.1.0",
+        "lodash": "^4.17.21",
+        "stream-chain": "^3.0.1",
+        "stream-json": "^1.8.0"
+      },
+      "engines": {
+        "node": ">= 14.0"
+      }
+    },
+    "node_modules/@bundle-stats/html-templates": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@bundle-stats/html-templates/-/html-templates-4.17.0.tgz",
+      "integrity": "sha512-B9AYHV1hyioS8S5qpWmP7vEn1npBWJHV/tSEHRFQTJOpGZdn6L0jHyzvofRvopqirTff++UpVS3TelN+Elh/tQ=="
+    },
+    "node_modules/@bundle-stats/plugin-webpack-filter": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@bundle-stats/plugin-webpack-filter/-/plugin-webpack-filter-4.17.0.tgz",
+      "integrity": "sha512-sGC1c7oiRNKY19OLNB2Yha88Yt+UC7OJWlk8O6HBvN/OO8ACvZ6DuxRMNBXMyP0cDDAJlcY9v9rzy0bbnegzAw==",
+      "engines": {
+        "node": ">= 14.0"
+      },
+      "peerDependencies": {
+        "core-js": "^3.0.0"
+      }
+    },
+    "node_modules/@bundle-stats/plugin-webpack-validate": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@bundle-stats/plugin-webpack-validate/-/plugin-webpack-validate-4.17.0.tgz",
+      "integrity": "sha512-dsCAIYiQ1ohRt7wyR5gfQCT3OKLjHxRZ3F/uL0gnBO56+xnvDzO/s+A5QO4EerlXIRIUBW8JWWuYAhe8ccdFjA==",
+      "dependencies": {
+        "lodash": "4.17.21",
+        "superstruct": "2.0.2"
+      },
+      "engines": {
+        "node": ">= 14.0"
+      }
+    },
+    "node_modules/@bundle-stats/utils": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@bundle-stats/utils/-/utils-4.17.0.tgz",
+      "integrity": "sha512-0/8/hebdV7QzPBZW7uyKClWpSsxVsQ/DfDwmNkmXSOq45eTeVNXozyvdYgwmLz0Ff9tVMyXu0Kb6iAVL6Hpt+g==",
+      "dependencies": {
+        "@bundle-stats/plugin-webpack-filter": "^4.17.0",
+        "@bundle-stats/plugin-webpack-validate": "^4.17.0",
+        "serialize-query-params": "2.0.2"
+      },
+      "engines": {
+        "node": ">= 14.0"
+      },
+      "peerDependencies": {
+        "core-js": "^3.0.0",
+        "lodash": "^4.0.0"
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1306,7 +1369,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1319,7 +1381,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1332,7 +1393,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1345,7 +1405,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1358,7 +1417,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1371,7 +1429,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1384,7 +1441,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1397,7 +1453,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1410,7 +1465,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1423,7 +1477,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1436,7 +1489,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1449,7 +1501,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1462,7 +1513,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1475,7 +1525,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1488,7 +1537,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1501,7 +1549,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1551,8 +1598,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/@types/glob-to-regexp": {
       "version": "0.4.4",
@@ -2412,6 +2458,11 @@
         "node": ">=14"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2423,6 +2474,17 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/core-js": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
+      "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
+      "hasInstallScript": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -3523,6 +3585,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3613,7 +3713,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -4782,6 +4881,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5416,6 +5520,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -5469,7 +5581,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5593,6 +5704,65 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/playwright": {
@@ -5938,7 +6108,6 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
       "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -5967,6 +6136,32 @@
         "@rollup/rollup-win32-ia32-msvc": "4.24.0",
         "@rollup/rollup-win32-x64-msvc": "4.24.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-bundle-stats": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-bundle-stats/-/rollup-plugin-bundle-stats-4.17.0.tgz",
+      "integrity": "sha512-qib0al0arhVlF1/nXynKNXbE5uUWuGr0GNzs+Dpub8Wu2bEvb3m5WaMpotXrK8d4pYoBpC8v38fXSqH0H+tapA==",
+      "dependencies": {
+        "@bundle-stats/cli-utils": "^4.17.0",
+        "rollup-plugin-webpack-stats": "0.4.1"
+      },
+      "engines": {
+        "node": ">= 16.0"
+      },
+      "peerDependencies": {
+        "rollup": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-webpack-stats": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-webpack-stats/-/rollup-plugin-webpack-stats-0.4.1.tgz",
+      "integrity": "sha512-Zi7t0G7FtA55LNcU9B3s2gBo3PODbdo+288Cw2/4sA8+o9H/ahhWZ25UxADeHwriAzW808iDpPbB81C5jGLIbg==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "rollup": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -6083,6 +6278,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/serialize-query-params": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.2.tgz",
+      "integrity": "sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -6278,6 +6478,14 @@
       "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
       "dev": true
     },
+    "node_modules/stream-chain": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-3.3.2.tgz",
+      "integrity": "sha512-YvRznt2X9tLSQlQXkYxp9FGcp6uUwBG9VAyjgo53Ov+Ctk36R49xB6NUia37T7owHyi3UtvI6achAj4ufBSaNg==",
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
+      }
+    },
     "node_modules/stream-combiner": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
@@ -6286,6 +6494,19 @@
       "dependencies": {
         "duplexer": "~0.1.1"
       }
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
+    "node_modules/stream-json/node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -6594,6 +6815,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -81,8 +81,7 @@
     "@floating-ui/dom": "^1.6.12",
     "@types/css-tree": "^2.3.8",
     "css-tree": "^3.0.0",
-    "nanoid": "^5.0.8",
-    "rollup-plugin-bundle-stats": "^4.17.0"
+    "nanoid": "^5.0.8"
   },
   "devDependencies": {
     "@playwright/test": "1.43.1",
@@ -106,6 +105,7 @@
     "node-fetch": "^2.6.7",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.3",
+    "rollup-plugin-bundle-stats": "^4.17.0",
     "selenium-webdriver": "^4.26.0",
     "stylelint": "^16.10.0",
     "stylelint-config-standard": "^36.0.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "@floating-ui/dom": "^1.6.12",
     "@types/css-tree": "^2.3.8",
     "css-tree": "^3.0.0",
-    "nanoid": "^5.0.8"
+    "nanoid": "^5.0.8",
+    "rollup-plugin-bundle-stats": "^4.17.0"
   },
   "devDependencies": {
     "@playwright/test": "1.43.1",

--- a/src/@types/css-tree.d.ts
+++ b/src/@types/css-tree.d.ts
@@ -3,6 +3,7 @@ declare module 'css-tree/walker' {
 
   export default walk;
 }
+
 declare module 'css-tree/utils' {
   export { clone, List } from 'css-tree';
 }
@@ -12,6 +13,7 @@ declare module 'css-tree/generator' {
 
   export default generate;
 }
+
 declare module 'css-tree/parser' {
   import { parse } from 'css-tree';
 

--- a/src/@types/css-tree.d.ts
+++ b/src/@types/css-tree.d.ts
@@ -1,0 +1,19 @@
+declare module 'css-tree/walker' {
+  import { walk } from 'css-tree';
+
+  export default walk;
+}
+declare module 'css-tree/utils' {
+  export { clone, List } from 'css-tree';
+}
+
+declare module 'css-tree/generator' {
+  import { generate } from 'css-tree';
+
+  export default generate;
+}
+declare module 'css-tree/parser' {
+  import { parse } from 'css-tree';
+
+  export default parse;
+}

--- a/src/cascade.ts
+++ b/src/cascade.ts
@@ -1,4 +1,4 @@
-import { type Block, type CssNode } from 'css-tree';
+import type { Block, CssNode } from 'css-tree';
 import walk from 'css-tree/walker';
 
 import {

--- a/src/cascade.ts
+++ b/src/cascade.ts
@@ -1,4 +1,5 @@
-import * as csstree from 'css-tree';
+import { type Block, type CssNode, } from 'css-tree';
+import walk from 'css-tree/walker';
 
 import {
   generateCSS,
@@ -34,10 +35,7 @@ export const SHIFTED_PROPERTIES: Record<string, string> = {
  * Shift property declarations for properties that are not yet natively
  * supported into custom properties.
  */
-function shiftUnsupportedProperties(
-  node: csstree.CssNode,
-  block?: csstree.Block,
-) {
+function shiftUnsupportedProperties(node: CssNode, block?: Block) {
   if (isDeclaration(node) && SHIFTED_PROPERTIES[node.property] && block) {
     block.children.appendData({
       ...node,
@@ -56,7 +54,7 @@ export function cascadeCSS(styleData: StyleData[]) {
   for (const styleObj of styleData) {
     let changed = false;
     const ast = getAST(styleObj.css);
-    csstree.walk(ast, {
+    walk(ast, {
       visit: 'Declaration',
       enter(node) {
         const block = this.rule?.block;

--- a/src/cascade.ts
+++ b/src/cascade.ts
@@ -1,4 +1,4 @@
-import { type Block, type CssNode, } from 'css-tree';
+import { type Block, type CssNode } from 'css-tree';
 import walk from 'css-tree/walker';
 
 import {

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -9,8 +9,8 @@ import {
   type SelectorList,
   type Value,
 } from 'css-tree';
+import { clone, List } from 'css-tree/utils';
 import walk from 'css-tree/walker';
-import {clone, List} from 'css-tree/utils';
 import { nanoid } from 'nanoid/non-secure';
 
 import { getCSSPropertyValue } from './dom.js';

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -1,13 +1,13 @@
-import {
-  type Atrule,
-  type Block,
-  type CssNode,
-  type Declaration,
-  type Identifier,
-  type Raw,
-  type Rule,
-  type SelectorList,
-  type Value,
+import type {
+  Atrule,
+  Block,
+  CssNode,
+  Declaration,
+  Identifier,
+  Raw,
+  Rule,
+  SelectorList,
+  Value,
 } from 'css-tree';
 import { clone, List } from 'css-tree/utils';
 import walk from 'css-tree/walker';

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,11 +1,11 @@
-import {
-  type CssNode,
-  type Declaration,
-  type FunctionNode,
-  type Identifier,
-  type List,
-  type Percentage,
-  type SelectorList,
+import type {
+  CssNode,
+  Declaration,
+  FunctionNode,
+  Identifier,
+  List,
+  Percentage,
+  SelectorList,
 } from 'css-tree';
 import walk from 'css-tree/walker';
 import { nanoid } from 'nanoid/non-secure';

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,4 +1,13 @@
-import * as csstree from 'css-tree';
+import {
+  type CssNode,
+  type Declaration,
+  type FunctionNode,
+  type Identifier,
+  type List,
+  type Percentage,
+  type SelectorList,
+} from 'css-tree';
+import walk from 'css-tree/walker';
 import { nanoid } from 'nanoid/non-secure';
 
 import {
@@ -71,44 +80,34 @@ export interface TryBlock {
   declarations: Partial<Record<AcceptedPositionTryProperty, string>>;
 }
 
-function isAnchorNameDeclaration(
-  node: csstree.CssNode,
-): node is DeclarationWithValue {
+function isAnchorNameDeclaration(node: CssNode): node is DeclarationWithValue {
   return node.type === 'Declaration' && node.property === 'anchor-name';
 }
 
-function isAnchorScopeDeclaration(
-  node: csstree.CssNode,
-): node is DeclarationWithValue {
+function isAnchorScopeDeclaration(node: CssNode): node is DeclarationWithValue {
   return node.type === 'Declaration' && node.property === 'anchor-scope';
 }
 
-function isAnchorSizeFunction(
-  node: csstree.CssNode | null,
-): node is csstree.FunctionNode {
+function isAnchorSizeFunction(node: CssNode | null): node is FunctionNode {
   return Boolean(
     node && node.type === 'Function' && node.name === 'anchor-size',
   );
 }
 
-function isVarFunction(
-  node: csstree.CssNode | null,
-): node is csstree.FunctionNode {
+function isVarFunction(node: CssNode | null): node is FunctionNode {
   return Boolean(node && node.type === 'Function' && node.name === 'var');
 }
 
-export function isIdentifier(
-  node: csstree.CssNode,
-): node is csstree.Identifier {
+export function isIdentifier(node: CssNode): node is Identifier {
   return Boolean(node.type === 'Identifier' && node.name);
 }
 
-function isPercentage(node: csstree.CssNode): node is csstree.Percentage {
+function isPercentage(node: CssNode): node is Percentage {
   return Boolean(node.type === 'Percentage' && node.value);
 }
 
 function parseAnchorFn(
-  node: csstree.FunctionNode,
+  node: FunctionNode,
   replaceCss?: boolean,
 ): AnchorFunction {
   let anchorName: string | undefined,
@@ -118,7 +117,7 @@ function parseAnchorFn(
     foundComma = false,
     customPropName: string | undefined;
 
-  const args: csstree.CssNode[] = [];
+  const args: CssNode[] = [];
   node.children.toArray().forEach((child) => {
     if (foundComma) {
       fallbackValue = `${fallbackValue}${generateCSS(child)}`;
@@ -131,7 +130,7 @@ function parseAnchorFn(
     args.push(child);
   });
 
-  let [name, sideOrSize]: (csstree.CssNode | undefined)[] = args;
+  let [name, sideOrSize]: (CssNode | undefined)[] = args;
   if (!sideOrSize) {
     // If we only have one argument assume it is the (required) anchor-side/size
     sideOrSize = name;
@@ -143,7 +142,7 @@ function parseAnchorFn(
       anchorName = name.name;
     } else if (isVarFunction(name) && name.children.first) {
       // Store CSS custom prop for anchor name
-      customPropName = (name.children.first as csstree.Identifier).name;
+      customPropName = (name.children.first as Identifier).name;
     }
   }
   if (sideOrSize) {
@@ -187,9 +186,7 @@ function parseAnchorFn(
 }
 
 function getAnchorNames(node: DeclarationWithValue) {
-  return (node.value.children as csstree.List<csstree.Identifier>).map(
-    ({ name }) => name,
-  );
+  return (node.value.children as List<Identifier>).map(({ name }) => name);
 }
 
 let anchorNames: AnchorSelectors = {};
@@ -217,10 +214,7 @@ function resetStores() {
   customPropReplacements = {};
 }
 
-function getAnchorFunctionData(
-  node: csstree.CssNode,
-  declaration: csstree.Declaration | null,
-) {
+function getAnchorFunctionData(node: CssNode, declaration: Declaration | null) {
   if ((isAnchorFunction(node) || isAnchorSizeFunction(node)) && declaration) {
     if (declaration.property.startsWith('--')) {
       const original = generateCSS(declaration.value);
@@ -287,8 +281,8 @@ export async function parseCSS(styleData: StyleData[]) {
   for (const styleObj of styleData) {
     let changed = false;
     const ast = getAST(styleObj.css);
-    csstree.walk(ast, function (node) {
-      const rule = this.rule?.prelude as csstree.SelectorList | undefined;
+    walk(ast, function (node) {
+      const rule = this.rule?.prelude as SelectorList | undefined;
       const selectors = getSelectors(rule);
 
       // Parse `anchor-name` declaration
@@ -374,10 +368,10 @@ export async function parseCSS(styleData: StyleData[]) {
     for (const styleObj of styleData) {
       let changed = false;
       const ast = getAST(styleObj.css);
-      csstree.walk(ast, {
+      walk(ast, {
         visit: 'Function',
         enter(node) {
-          const rule = this.rule?.prelude as csstree.SelectorList | undefined;
+          const rule = this.rule?.prelude as SelectorList | undefined;
           const declaration = this.declaration;
           const prop = declaration?.property;
           if (
@@ -386,13 +380,11 @@ export async function parseCSS(styleData: StyleData[]) {
             declaration &&
             prop &&
             node.children.first &&
-            customPropsToCheck.has(
-              (node.children.first as csstree.Identifier).name,
-            ) &&
+            customPropsToCheck.has((node.children.first as Identifier).name) &&
             // For now, we only want assignments to other CSS custom properties
             prop.startsWith('--')
           ) {
-            const child = node.children.first as csstree.Identifier;
+            const child = node.children.first as Identifier;
             // Find anchor data assigned to this custom property
             const anchorFns = customPropAssignments[child.name] ?? [];
             // Find anchor data assigned to another custom property referenced
@@ -444,10 +436,10 @@ export async function parseCSS(styleData: StyleData[]) {
   for (const styleObj of styleData) {
     let changed = false;
     const ast = getAST(styleObj.css);
-    csstree.walk(ast, {
+    walk(ast, {
       visit: 'Function',
       enter(node) {
-        const rule = this.rule?.prelude as csstree.SelectorList | undefined;
+        const rule = this.rule?.prelude as SelectorList | undefined;
         const declaration = this.declaration;
         const prop = declaration?.property;
 
@@ -460,7 +452,7 @@ export async function parseCSS(styleData: StyleData[]) {
           // Now we only want assignments to inset/sizing properties
           (isInsetProp(prop) || isSizingProp(prop))
         ) {
-          const child = node.children.first as csstree.Identifier;
+          const child = node.children.first as Identifier;
           // Find anchor data assigned to this custom property
           const anchorFns = customPropAssignments[child.name] ?? [];
           // Find anchor data assigned to another custom property referenced
@@ -604,18 +596,16 @@ export async function parseCSS(styleData: StyleData[]) {
     for (const styleObj of styleData) {
       let changed = false;
       const ast = getAST(styleObj.css);
-      csstree.walk(ast, {
+      walk(ast, {
         visit: 'Function',
         enter(node) {
           if (
             isVarFunction(node) &&
-            (node.children.first as csstree.Identifier)?.name?.startsWith(
-              '--',
-            ) &&
+            (node.children.first as Identifier)?.name?.startsWith('--') &&
             this.declaration?.property?.startsWith('--') &&
             this.block
           ) {
-            const child = node.children.first as csstree.Identifier;
+            const child = node.children.first as Identifier;
             const positions = customPropReplacements[child.name];
             if (positions) {
               for (const [propUuid, value] of Object.entries(positions)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,16 @@
-import * as csstree from 'css-tree';
+import {
+  type CssNode,
+  type Declaration,
+  type FunctionNode,
+  type Identifier,
+  type List,
+  type Selector as CssTreeSelector,
+  type SelectorList,
+  type Value,
+} from 'css-tree';
+import {clone} from 'css-tree/utils';
+import parse from 'css-tree/parser';
+import generate from 'css-tree/generator';
 import { nanoid } from 'nanoid/non-secure';
 
 import type { Selector } from './dom.js';
@@ -6,40 +18,36 @@ import type { Selector } from './dom.js';
 export const INSTANCE_UUID = nanoid();
 
 // https://github.com/import-js/eslint-plugin-import/issues/3019
-// eslint-disable-next-line import/namespace
-export interface DeclarationWithValue extends csstree.Declaration {
-  value: csstree.Value;
+ 
+export interface DeclarationWithValue extends Declaration {
+  value: Value;
 }
 
-export function isAnchorFunction(
-  node: csstree.CssNode | null,
-): node is csstree.FunctionNode {
+export function isAnchorFunction(node: CssNode | null): node is FunctionNode {
   return Boolean(node && node.type === 'Function' && node.name === 'anchor');
 }
 
 export function getAST(cssText: string) {
-  return csstree.parse(cssText, {
+  return parse(cssText, {
     parseAtrulePrelude: false,
     parseCustomProperty: true,
   });
 }
 
-export function generateCSS(ast: csstree.CssNode) {
-  return csstree.generate(ast, {
+export function generateCSS(ast: CssNode) {
+  return generate(ast, {
     // Default `safe` adds extra (potentially breaking) spaces for compatibility
     // with old browsers.
     mode: 'spec',
   });
 }
 
-export function isDeclaration(
-  node: csstree.CssNode,
-): node is DeclarationWithValue {
+export function isDeclaration(node: CssNode): node is DeclarationWithValue {
   return node.type === 'Declaration';
 }
 
 export function getDeclarationValue(node: DeclarationWithValue) {
-  return (node.value.children.first as csstree.Identifier).name;
+  return (node.value.children.first as Identifier).name;
 }
 
 export interface StyleData {
@@ -51,9 +59,9 @@ export interface StyleData {
 
 export const POSITION_ANCHOR_PROPERTY = `--position-anchor-${INSTANCE_UUID}`;
 
-export function splitCommaList(list: csstree.List<csstree.CssNode>) {
+export function splitCommaList(list: List<CssNode>) {
   return list.toArray().reduce(
-    (acc: csstree.Identifier[][], child) => {
+    (acc: Identifier[][], child) => {
       if (child.type === 'Operator' && child.value === ',') {
         acc.push([]);
         return acc;
@@ -68,15 +76,15 @@ export function splitCommaList(list: csstree.List<csstree.CssNode>) {
   );
 }
 
-export function getSelectors(rule: csstree.SelectorList | undefined) {
+export function getSelectors(rule: SelectorList | undefined) {
   if (!rule) return [];
 
-  return (rule.children as csstree.List<csstree.Selector>)
+  return (rule.children as List<CssTreeSelector>)
     .map((selector) => {
       let pseudoElementPart: string | undefined;
 
       if (selector.children.last?.type === 'PseudoElementSelector') {
-        selector = csstree.clone(selector) as csstree.Selector;
+        selector = clone(selector) as CssTreeSelector;
         pseudoElementPart = generateCSS(selector.children.last!);
         selector.children.pop();
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,12 @@
-import {
-  type CssNode,
-  type Declaration,
-  type FunctionNode,
-  type Identifier,
-  type List,
-  type Selector as CssTreeSelector,
-  type SelectorList,
-  type Value,
+import type {
+  CssNode,
+  Declaration,
+  FunctionNode,
+  Identifier,
+  List,
+  Selector as CssTreeSelector,
+  SelectorList,
+  Value,
 } from 'css-tree';
 import generate from 'css-tree/generator';
 import parse from 'css-tree/parser';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,9 +8,9 @@ import {
   type SelectorList,
   type Value,
 } from 'css-tree';
-import {clone} from 'css-tree/utils';
-import parse from 'css-tree/parser';
 import generate from 'css-tree/generator';
+import parse from 'css-tree/parser';
+import { clone } from 'css-tree/utils';
 import { nanoid } from 'nanoid/non-secure';
 
 import type { Selector } from './dom.js';
@@ -18,7 +18,7 @@ import type { Selector } from './dom.js';
 export const INSTANCE_UUID = nanoid();
 
 // https://github.com/import-js/eslint-plugin-import/issues/3019
- 
+
 export interface DeclarationWithValue extends Declaration {
   value: Value;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 
 import { resolve } from 'path';
+import { bundleStats } from 'rollup-plugin-bundle-stats';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
@@ -38,6 +39,7 @@ export default defineConfig({
         target: 'es6',
         sourcemap: true,
       },
+  plugins: [bundleStats()],
   /**
    * @see https://vitest.dev/config/#configuration
    */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,7 +43,6 @@ export default defineConfig({
         },
       },
   plugins: [bundleStats()],
-  
   /**
    * @see https://vitest.dev/config/#configuration
    */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,8 +38,12 @@ export default defineConfig({
         emptyOutDir: !process.env.BUILD_FN,
         target: 'es6',
         sourcemap: true,
+        rollupOptions: {
+          external: [/source-map-js/],
+        },
       },
   plugins: [bundleStats()],
+  
   /**
    * @see https://vitest.dev/config/#configuration
    */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,9 +40,16 @@ export default defineConfig({
         sourcemap: true,
         rollupOptions: {
           external: [/source-map-js/],
+          // This is not needed, but silences a Rollup warning
+          output: {
+            globals: {
+              'source-map-js/lib/source-map-generator.js':
+                'sourceMapGenerator_js',
+            },
+          },
         },
       },
-  plugins: [bundleStats()],
+  plugins: [bundleStats({ compare: false, silent: true })],
   /**
    * @see https://vitest.dev/config/#configuration
    */


### PR DESCRIPTION
## Description
This reduces the size of the built library from 223.72KiB to 105.54KiB by:

1. Switching to using more granular imports for csstree. 
2. Removing `source-map-js` from the built library. Source maps are still generated, but the module itself isn't needed.

Pre-merge cleanup:
- [ ] Remove bundle-stats plugin?

## Related Issue(s)
#276 


## Steps to test/reproduce

- Verify that the demo works locally, by building, and then changing the import in index.html to `import polyfill from '/dist/css-anchor-positioning-fn.js';`
- Locally, run `npm run build; open dist/bundle-stats.html` to check the results. (You can compare with the current build on the `prev-stats` branch, which has the bundle-stats plugin installed with no modifications to main.

## Show me

**Before**
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/2a7dddb4-83f2-4bdf-a451-977f6c9401c3">

**After**
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/da252284-7806-45bf-9ad1-6bbbf5698dac">

