### PR TITLE
Allow multiple position-area declarations for a single selector

### DIFF
--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -594,7 +594,7 @@ export async function polyfill(
   let styleData = await fetchCSS(options.elements, options.excludeInlineStyles);
 
   // pre parse CSS styles that we need to cascade
-  const cascadeCausedChanges = await cascadeCSS(styleData);
+  const cascadeCausedChanges = cascadeCSS(styleData);
   if (cascadeCausedChanges) {
     styleData = await transformCSS(styleData);
   }


### PR DESCRIPTION
Given:

```css
.target {
  position-area: start;
}

.target {
  position-area: end;
}
```

Before, whichever one we parse last would be applied. Now this stores all of them, and allows the cascade to determine which one should be applied. (Or at least I think so -- some quick functional testing seemed to confirm that this works as expected.)