### PR TITLE
Cascade `position-area` with :where:not

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -19,6 +19,7 @@ import {
 import { parsePositionFallbacks, type PositionTryOrder } from './fallback.js';
 import {
   activeWrapperStyles,
+  cascadedWrapperStyles,
   getPositionAreaData,
   type PositionAreaData,
   wrapperForPositionedElement,
@@ -759,9 +760,9 @@ export async function parseCSS(styleData: StyleData[]) {
       for (const positionData of positions) {
         const targetUUID = `--pa-target-${nanoid(12)}`;
         const wrapperEl = wrapperForPositionedElement(targetEl, targetUUID);
-        positionAreaMappingStyleElement.css += activeWrapperStyles(
+        positionAreaMappingStyleElement.css += cascadedWrapperStyles(
+          targetSel,
           targetUUID,
-          positionData.selectorUUID,
         );
         positionAreaMappingStyleElement.changed = true;
         // Populate new data for each anchor/target combo

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -18,7 +18,7 @@ import {
 } from './dom.js';
 import { parsePositionFallbacks, type PositionTryOrder } from './fallback.js';
 import {
-  activeWrapperStyles,
+  // activeWrapperStyles,
   cascadedWrapperStyles,
   getPositionAreaData,
   type PositionAreaData,

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -410,7 +410,7 @@ export function activeWrapperStyles(targetUUID: string, selectorUUID: string) {
   `.replaceAll('\n', '');
 }
 
-export function cascadedWrapperStyles(selector: string, targetUUID: string){
+export function cascadedWrapperStyles(selector: string, targetUUID: string) {
   return `
   :where([${WRAPPER_TARGET_ATTRIBUTE_PRELUDE}${targetUUID}]):not(${selector}){
     --pa-value-top: var(${targetUUID}-top);
@@ -419,5 +419,5 @@ export function cascadedWrapperStyles(selector: string, targetUUID: string){
     --pa-value-bottom: var(${targetUUID}-bottom);
     --pa-value-justify-self: var(${targetUUID}-justify-self);
     --pa-value-align-self: var(${targetUUID}-align-self);
-}`
+}`;
 }

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -409,3 +409,15 @@ export function activeWrapperStyles(targetUUID: string, selectorUUID: string) {
     }
   `.replaceAll('\n', '');
 }
+
+export function cascadedWrapperStyles(selector: string, targetUUID: string){
+  return `
+  :where([${WRAPPER_TARGET_ATTRIBUTE_PRELUDE}${targetUUID}]):not(${selector}){
+    --pa-value-top: var(${targetUUID}-top);
+    --pa-value-left: var(${targetUUID}-left);
+    --pa-value-right: var(${targetUUID}-right);
+    --pa-value-bottom: var(${targetUUID}-bottom);
+    --pa-value-justify-self: var(${targetUUID}-justify-self);
+    --pa-value-align-self: var(${targetUUID}-align-self);
+}`
+}


### PR DESCRIPTION
## Description
This is an alternate method of ensuring the correct value cascades in instances where multiple values for `position-area` apply to the same element.

```css
.a #b{
  position-area: end;
}
.a .b{
  position-area: start;
}
```
This should resolve to `end` due to specificity.

In other parts of the polyfill, we can simply add properties to the same declaration blocks to ensure they cascade as expected. However, `position-area` requires us to add properties to a generated parent element of the selected element. This PR uses `:where([parent]):not([original selector])` to properly handle the cascade.

The `:where()` selects the specific element, and the `:not()` applies that rule with the same specificity of the original selector.  The example above creates the following selectors-

```css
:where([parent]):not(.a #b){ /**rules **/}
:where([parent]):not(.a .b){ /**rules **/}
```

The alternate method, as implemented in #296, checks for a cascade winner each time the polyfill is updated. This adds a bit 

## Related Issue(s)

#181 

## Steps to test/reproduce

In the demo, go to the Cascade example. 
https://deploy-preview-307--anchor-polyfill.netlify.app/position-area#cascade
If you apply the polyfill, it will be positioned at `top right`. If you reload the page, click the "Switch cascade button", and apply the polyfill, it will be positioned at `bottom right`.

## Caveats

1. This moves the earliest supported browsers to Chromium 88, Firefox 84, Safari 14, or roughly 4 years. This would only impact people using `position-area`, though.
2. This selector doesn't check if the original selector still applies. For instance, in the Cascade example, if you switch the cascade, apply the polyfill, and switch the cascade again, the `.cascade-override` class is no longer present in the document, but the `:where([parent]):not(.cascade-override #cascade-target)` selector still applies. 