### PR TITLE
Allow anchor-size on margin and inset properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,6 +963,37 @@
   width: anchor-size(--my-anchor width);
 }</code></pre>
     </section>
+    <section
+      id="anchor-size-extended"
+      class="demo-item"
+      style="position: relative"
+    >
+      <h2>
+        <a href="#anchor-size-extended" aria-hidden="true">🔗</a>
+        <code>anchor-size()</code> on margin and inset
+      </h2>
+      <div class="demo-elements">
+        <div id="my-anchor-anchor-size-extended" class="anchor">Anchor</div>
+        <div id="my-target-anchor-size-extended" class="target">Target</div>
+      </div>
+      <p class="note">
+        With polyfill applied: Target's <code>margin</code> is the height of the
+        anchor, and its <code>right</code> inset is the width of the anchor.
+      </p>
+      <pre><code class="language-css"
+>#my-anchor-anchor-size-extended {
+  anchor-name: --my-anchor-size-extended;
+  resize: both;
+  overflow: hidden;
+}
+
+#my-target-anchor-size-extended {
+  position: absolute;
+  position-anchor: --my-anchor-size-extended;
+  right: anchor-size(width);
+  margin: anchor-size(height);
+}</code></pre>
+    </section>
     <section id="anchor-update" class="demo-item">
       <h2>
         <a href="#anchor-update" aria-hidden="true">🔗</a>
@@ -1243,37 +1274,6 @@ CSS inside the anchor-manual.css file:
   position-anchor: --anchor-scope;
   left: anchor(right);
   top: anchor(center);
-}</code></pre>
-    </section>
-    <section
-      id="anchor-size-extended"
-      class="demo-item"
-      style="position: relative"
-    >
-      <h2>
-        <a href="#anchor-size-extended" aria-hidden="true">🔗</a>
-        <code>anchor-size()</code> on margin and inset
-      </h2>
-      <div class="demo-elements">
-        <div id="my-anchor-anchor-size-extended" class="anchor">Anchor</div>
-        <div id="my-target-anchor-size-extended" class="target">Target</div>
-      </div>
-      <p class="note">
-        With polyfill applied: Target's <code>margin</code> is the height of the
-        anchor, and its <code>right</code> inset is the width of the anchor.
-      </p>
-      <pre><code class="language-css"
->#my-anchor-anchor-size-extended{
-  anchor-name: --my-anchor-size-extended;
-  resize: both;
-  overflow: hidden;
-}
-
-#my-target-anchor-size-extended{
-  position: absolute;
-  position-anchor: --my-anchor-size-extended;
-  right: anchor-size(width);
-  margin: anchor-size(height);
 }</code></pre>
     </section>
     <section id="sponsor">

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     <link rel="stylesheet" href="/position-anchor.css" />
     <link rel="stylesheet" href="/anchor-scroll.css" />
     <link rel="stylesheet" href="/anchor-size.css" />
+    <link rel="stylesheet" href="/anchor-size-extended.css" />
     <link rel="stylesheet" href="/anchor-math.css" />
     <link rel="stylesheet" href="/anchor-name-custom-prop.css" />
     <link rel="stylesheet" href="/anchor-name-list.css" />
@@ -1242,6 +1243,37 @@ CSS inside the anchor-manual.css file:
   position-anchor: --anchor-scope;
   left: anchor(right);
   top: anchor(center);
+}</code></pre>
+    </section>
+    <section
+      id="anchor-size-extended"
+      class="demo-item"
+      style="position: relative"
+    >
+      <h2>
+        <a href="#anchor-size-extended" aria-hidden="true">🔗</a>
+        <code>anchor-size()</code> on margin and inset
+      </h2>
+      <div class="demo-elements">
+        <div id="my-anchor-anchor-size-extended" class="anchor">Anchor</div>
+        <div id="my-target-anchor-size-extended" class="target">Target</div>
+      </div>
+      <p class="note">
+        With polyfill applied: Target's <code>margin</code> is the height of the
+        anchor, and its <code>right</code> inset is the width of the anchor.
+      </p>
+      <pre><code class="language-css"
+>#my-anchor-anchor-size-extended{
+  anchor-name: --my-anchor-size-extended;
+  resize: both;
+  overflow: hidden;
+}
+
+#my-target-anchor-size-extended{
+  position: absolute;
+  position-anchor: --my-anchor-size-extended;
+  right: anchor-size(width);
+  margin: anchor-size(height);
 }</code></pre>
     </section>
     <section id="sponsor">

--- a/public/anchor-size-extended.css
+++ b/public/anchor-size-extended.css
@@ -1,0 +1,12 @@
+#my-anchor-anchor-size-extended {
+  anchor-name: --my-anchor-size-extended;
+  resize: both;
+  overflow: hidden;
+}
+
+#my-target-anchor-size-extended {
+  position: absolute;
+  position-anchor: --my-anchor-size-extended;
+  right: anchor-size(width);
+  margin: anchor-size(height);
+}

--- a/src/cascade.ts
+++ b/src/cascade.ts
@@ -29,7 +29,6 @@ export const SHIFTED_PROPERTIES: Record<string, string> = {
   'inset-block': `--inset-block-${INSTANCE_UUID}`,
   'inset-inline': `--inset-inline-${INSTANCE_UUID}`,
   inset: `--inset-${INSTANCE_UUID}`,
-  margin: `--margin-${INSTANCE_UUID}`,
 };
 
 /**

--- a/src/cascade.ts
+++ b/src/cascade.ts
@@ -29,6 +29,7 @@ export const SHIFTED_PROPERTIES: Record<string, string> = {
   'inset-block': `--inset-block-${INSTANCE_UUID}`,
   'inset-inline': `--inset-inline-${INSTANCE_UUID}`,
   inset: `--inset-${INSTANCE_UUID}`,
+  margin: `--margin-${INSTANCE_UUID}`,
 };
 
 /**

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -22,6 +22,7 @@ import {
   type AnchorSide,
   type AnchorSize,
   type InsetProperty,
+  isAcceptedPositionTryProp,
   isAnchorSide,
   isAnchorSize,
   isInsetProp,
@@ -53,10 +54,13 @@ export interface AnchorFunction {
   uuid: string;
 }
 
-// `key` is the property being declared
-// `value` is the anchor-positioning data for that property
+// `key` is the property being declared `value` is the anchor-positioning data
+// for that property While AcceptedPositionTryProperty is a superset of the
+// properties that are actually useful, anchor-size technically can be applied
+// to any accepted position-try property, including the nonsensical
+// `place-self`.
 export type AnchorFunctionDeclaration = Partial<
-  Record<InsetProperty | SizingProperty, AnchorFunction[]>
+  Record<AcceptedPositionTryProperty, AnchorFunction[]>
 >;
 
 // `key` is the target element selector
@@ -228,8 +232,9 @@ function getAnchorFunctionData(node: CssNode, declaration: Declaration | null) {
       return { changed: true };
     }
     if (
-      isInsetProp(declaration.property) ||
-      isSizingProp(declaration.property)
+      (isAnchorFunction(node) && isInsetProp(declaration.property)) ||
+      (isAnchorSizeFunction(node) &&
+        isAcceptedPositionTryProp(declaration.property))
     ) {
       const data = parseAnchorFn(node, true);
       return { prop: declaration.property, data, changed: true };

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -54,11 +54,11 @@ export interface AnchorFunction {
   uuid: string;
 }
 
-// `key` is the property being declared `value` is the anchor-positioning data
-// for that property While AcceptedPositionTryProperty is a superset of the
-// properties that are actually useful, anchor-size technically can be applied
-// to any accepted position-try property, including the nonsensical
-// `place-self`.
+// - `key` is the property being declared
+// - `value` is the anchor-positioning data for that property
+// While AcceptedPositionTryProperty is a superset of the properties that are
+// actually useful, anchor-size technically can be applied to any accepted
+// position-try property, including the nonsensical `place-self`.
 export type AnchorFunctionDeclaration = Partial<
   Record<AcceptedPositionTryProperty, AnchorFunction[]>
 >;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -18,11 +18,12 @@ import {
 } from './dom.js';
 import { parsePositionFallbacks, type PositionTryOrder } from './fallback.js';
 import {
+  type AcceptedAnchorSizeProperty,
   type AcceptedPositionTryProperty,
   type AnchorSide,
   type AnchorSize,
   type InsetProperty,
-  isAcceptedPositionTryProp,
+  isAcceptedAnchorSizeProp,
   isAnchorSide,
   isAnchorSize,
   isInsetProp,
@@ -56,11 +57,10 @@ export interface AnchorFunction {
 
 // - `key` is the property being declared
 // - `value` is the anchor-positioning data for that property
-// While AcceptedPositionTryProperty is a superset of the properties that are
-// actually useful, anchor-size technically can be applied to any accepted
-// position-try property, including the nonsensical `place-self`.
+// The valid properties for `anchor()` is a subset of the properties that are
+// valid for `anchor-size()`, so functional validation should be used as well.
 export type AnchorFunctionDeclaration = Partial<
-  Record<AcceptedPositionTryProperty, AnchorFunction[]>
+  Record<AcceptedAnchorSizeProperty, AnchorFunction[]>
 >;
 
 // `key` is the target element selector
@@ -234,7 +234,7 @@ function getAnchorFunctionData(node: CssNode, declaration: Declaration | null) {
     if (
       (isAnchorFunction(node) && isInsetProp(declaration.property)) ||
       (isAnchorSizeFunction(node) &&
-        isAcceptedPositionTryProp(declaration.property))
+        isAcceptedAnchorSizeProp(declaration.property))
     ) {
       const data = parseAnchorFn(node, true);
       return { prop: declaration.property, data, changed: true };

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -21,7 +21,7 @@ import {
   type AnchorSide,
   type AnchorSize,
   type InsetProperty,
-  isAcceptedPositionTryProp,
+  isAcceptedAnchorSizeProp,
   isInsetProp,
   type SizingProperty,
 } from './syntax.js';
@@ -154,10 +154,7 @@ export const getPixelValue = async ({
     return fallback;
   }
   if (anchorSize) {
-    // anchor-size() is defined as usable on any prop that is acceptable in an
-    // @position-try block. Practically, only inset, margin and sizing are
-    // usable. https://drafts.csswg.org/css-anchor-position-1/#sizing
-    if (!isAcceptedPositionTryProp(targetProperty)) {
+    if (!isAcceptedAnchorSizeProp(targetProperty)) {
       return fallback;
     }
     // Calculate value for `anchor-size()` fn...

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -21,8 +21,8 @@ import {
   type AnchorSide,
   type AnchorSize,
   type InsetProperty,
+  isAcceptedPositionTryProp,
   isInsetProp,
-  isSizingProp,
   type SizingProperty,
 } from './syntax.js';
 import { transformCSS } from './transform.js';
@@ -154,9 +154,10 @@ export const getPixelValue = async ({
     return fallback;
   }
   if (anchorSize) {
-    // anchor-size() can only be assigned to sizing properties:
-    // https://drafts.csswg.org/css-anchor-1/#queries
-    if (!isSizingProp(targetProperty)) {
+    // anchor-size() is defined as usable on any prop that is acceptable in an
+    // @position-try block. Practically, only inset, margin and sizing are
+    // usable. https://drafts.csswg.org/css-anchor-position-1/#sizing
+    if (!isAcceptedPositionTryProp(targetProperty)) {
       return fallback;
     }
     // Calculate value for `anchor-size()` fn...

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -100,6 +100,24 @@ export function isAcceptedPositionTryProp(
   );
 }
 
+// Accepted anchor-size() properties
+export const ACCEPTED_ANCHOR_SIZE_PROPERTIES = [
+  ...SIZING_PROPS,
+  ...INSET_PROPS,
+  ...MARGIN_PROPERTIES,
+] as const;
+
+export type AcceptedAnchorSizeProperty =
+  (typeof ACCEPTED_ANCHOR_SIZE_PROPERTIES)[number];
+
+export function isAcceptedAnchorSizeProp(
+  property: string,
+): property is AcceptedAnchorSizeProperty {
+  return ACCEPTED_ANCHOR_SIZE_PROPERTIES.includes(
+    property as AcceptedAnchorSizeProperty,
+  );
+}
+
 // Anchor Side properties
 export const ANCHOR_SIDES = [
   'top',

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -92,6 +92,14 @@ export const ACCEPTED_POSITION_TRY_PROPERTIES = [
 export type AcceptedPositionTryProperty =
   (typeof ACCEPTED_POSITION_TRY_PROPERTIES)[number];
 
+export function isAcceptedPositionTryProp(
+  property: string,
+): property is AcceptedPositionTryProperty {
+  return ACCEPTED_POSITION_TRY_PROPERTIES.includes(
+    property as AcceptedPositionTryProperty,
+  );
+}
+
 // Anchor Side properties
 export const ANCHOR_SIDES = [
   'top',


### PR DESCRIPTION
## Description
https://drafts.csswg.org/css-anchor-position-1/#anchor-size-fn

Spec changed in https://github.com/w3c/csswg-drafts/issues/9827 to allow `anchor-size` on all properties that are allowed in `@position-try` blocks. This includes some nonsensical ones like `align-self`, which don't take lengths. I went with the "technically correct" tact of allowing anchor size to be used on those, but I alternatively could define a subset of the `@position-try` declarations that actually accept lengths. 

## Related Issue(s)
Fixes #288 

## Steps to test/reproduce
https://deploy-preview-309--anchor-polyfill.netlify.app/#anchor-size-extended