### PR TITLE
Alternate overflow options

### DIFF
--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -441,12 +441,13 @@ async function checkOverflow(target: HTMLElement, offsetParent: HTMLElement) {
       y: target.offsetTop,
       platform: platformWithCache,
       rects,
-      elements: { floating: target },
+      elements: {
+        floating: target,
+        reference: offsetParent,
+      },
       strategy: 'absolute',
     } as unknown as MiddlewareState,
     {
-      boundary: offsetParent,
-      rootBoundary: 'document',
       padding: getMargins(target),
     },
   );

--- a/tests/e2e/polyfill.test.ts
+++ b/tests/e2e/polyfill.test.ts
@@ -110,6 +110,7 @@ test('updates when sizes change', async ({ page }) => {
 test('applies polyfill for `@position-fallback`', async ({ page }) => {
   const targetSel = '#my-target-fallback';
   const target = page.locator(targetSel);
+  await target.scrollIntoViewIfNeeded();
 
   await expect(target).toHaveCSS('left', '0px');
 
@@ -124,6 +125,7 @@ test('applies polyfill for `@position-fallback`', async ({ page }) => {
   });
 
   await expect(target).toHaveCSS('width', '100px');
+  await expect(target).toHaveCSS('height', '100px');
 });
 
 test('applies manual polyfill', async ({ page }) => {


### PR DESCRIPTION
## Description
Overflow checking was not working as expected for `position-try-fallbacks` with the viewport as the containing block. 

## Related Issue(s)
#317 


## Steps to test/reproduce
- Verify [contained example ](https://deploy-preview-318--anchor-polyfill.netlify.app/#position-try)still works (Note that the Try Tactics example is broken currently- see #279)
- Verify the [viewport example](https://codepen.io/jamessw/pen/OPPLgrm) works in Codepen