### PR TITLE
Report invalid selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ style properties at runtime.
 If you are using inline styles to set anchor-related properties and the polyfill
 isn't working, verify that the inline styles are actually showing up in the DOM.
 
+### Invalid CSS
+
+Some types of invalid CSS will cause the polyfill to throw an error. In these
+cases, the polyfill will report any parse errors encountered in the console as
+warnings. This will be followed by the error thrown by the polyfill.
+
+The polyfill can't determine which parse error caused the polyfill error, but
+please resolve any reported parse errors before opening a bug. We also recommend
+using a CSS linter like [Stylelint](https://stylelint.io/) or
+[@eslint/css](https://github.com/eslint/css).
+
 ## Sponsor OddBird's OSS Work
 
 At OddBird, we love contributing to the languages & tools developers rely on.

--- a/src/cascade.ts
+++ b/src/cascade.ts
@@ -50,7 +50,7 @@ function shiftUnsupportedProperties(node: CssNode, block?: Block) {
 export function cascadeCSS(styleData: StyleData[]) {
   for (const styleObj of styleData) {
     let changed = false;
-    const ast = getAST(styleObj.css);
+    const ast = getAST(styleObj.css, true);
     walk(ast, {
       visit: 'Declaration',
       enter(node) {

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -32,7 +32,7 @@ import {
   type SizingProperty,
 } from './syntax.js';
 import { transformCSS } from './transform.js';
-import { cssParseErrors } from './utils.js';
+import { reportParseErrorsOnFailure, resetParseErrors } from './utils.js';
 
 const platformWithCache = { ...platform, _c: new Map() };
 
@@ -591,8 +591,17 @@ export async function polyfill(
 
   // fetch CSS from stylesheet and inline style
   let styleData = await fetchCSS(options.elements, options.excludeInlineStyles);
+
   let rules: AnchorPositions = {};
   let inlineStyles: Map<HTMLElement, Record<string, string>> | undefined;
+
+  // Reset the CSS parse errors in case the polyfill is run multiple times, and
+  // at the beginning in case a previous run failed.
+  resetParseErrors();
+
+  // If the polyfill fails during the steps in the try catch, it is likely due
+  // to invalid CSS, so report the CSS parse errors. Subsequent errors are less
+  // likely to be caused by parse errors.
   try {
     // pre parse CSS styles that we need to cascade
     const cascadeCausedChanges = cascadeCSS(styleData);
@@ -604,22 +613,7 @@ export async function polyfill(
     rules = parsedCSS.rules;
     inlineStyles = parsedCSS.inlineStyles;
   } catch (error) {
-    if (cssParseErrors.length > 0) {
-      // eslint-disable-next-line no-console
-      console.group(
-        `The CSS anchor positioning polyfill was not applied due to ${
-          cssParseErrors.length === 1
-            ? 'a CSS parse error.'
-            : 'CSS parse errors'
-        }.`,
-      );
-      cssParseErrors.forEach((err) => {
-        // eslint-disable-next-line no-console
-        console.warn(err.formattedMessage);
-      });
-      // eslint-disable-next-line no-console
-      console.groupEnd();
-    }
+    reportParseErrorsOnFailure();
     throw error;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,11 @@ export function getAST(cssText: string) {
   return parse(cssText, {
     parseAtrulePrelude: false,
     parseCustomProperty: true,
+    onParseError: (err) => {
+      const errorPrelude =
+        'Invalid CSS could not be parsed. CSS Anchor Positioning Polyfill was not applied.\n\n';
+      throw new Error(errorPrelude + err.formattedMessage, { cause: err });
+    },
   });
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,12 +30,12 @@ export function isAnchorFunction(node: CssNode | null): node is FunctionNode {
   return Boolean(node && node.type === 'Function' && node.name === 'anchor');
 }
 
-export function getAST(cssText: string) {
+export function getAST(cssText: string, captureErrors = false) {
   return parse(cssText, {
     parseAtrulePrelude: false,
     parseCustomProperty: true,
     onParseError: (err) => {
-      cssParseErrors.push(err);
+      if(captureErrors) cssParseErrors.push(err);
     },
   });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,11 @@ import type { Selector } from './dom.js';
 
 export const INSTANCE_UUID = nanoid();
 
-export const cssParseErrors = [] as SyntaxParseError[];
+/** Singleton to hold CSS parse errors in case polyfill fails.
+ *
+ * Not included in the store in parse.ts, as it has a different lifecycle.
+ */
+export const cssParseErrors = new Set() as Set<SyntaxParseError>;
 
 // https://github.com/import-js/eslint-plugin-import/issues/3019
 
@@ -29,13 +33,17 @@ export interface DeclarationWithValue extends Declaration {
 export function isAnchorFunction(node: CssNode | null): node is FunctionNode {
   return Boolean(node && node.type === 'Function' && node.name === 'anchor');
 }
-
+/**
+ * @param cssText
+ * @param captureErrors `true` only on the initial parse of CSS before the
+ * polyfill changes it
+ */
 export function getAST(cssText: string, captureErrors = false) {
   return parse(cssText, {
     parseAtrulePrelude: false,
     parseCustomProperty: true,
     onParseError: (err) => {
-      if(captureErrors) cssParseErrors.push(err);
+      if (captureErrors) cssParseErrors.add(err);
     },
   });
 }
@@ -105,4 +113,25 @@ export function getSelectors(rule: SelectorList | undefined) {
       } satisfies Selector;
     })
     .toArray();
+}
+
+export function reportParseErrorsOnFailure() {
+  if (cssParseErrors.size > 0) {
+    // eslint-disable-next-line no-console
+    console.group(
+      `The CSS anchor positioning polyfill was not applied due to ${
+        cssParseErrors.size === 1 ? 'a CSS parse error' : 'CSS parse errors'
+      }.`,
+    );
+    cssParseErrors.forEach((err) => {
+      // eslint-disable-next-line no-console
+      console.warn(err.formattedMessage);
+    });
+    // eslint-disable-next-line no-console
+    console.groupEnd();
+  }
+}
+
+export function resetParseErrors() {
+  cssParseErrors.clear();
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import type {
   List,
   Selector as CssTreeSelector,
   SelectorList,
+  SyntaxParseError,
   Value,
 } from 'css-tree';
 import generate from 'css-tree/generator';
@@ -16,6 +17,8 @@ import { nanoid } from 'nanoid/non-secure';
 import type { Selector } from './dom.js';
 
 export const INSTANCE_UUID = nanoid();
+
+export const cssParseErrors = [] as SyntaxParseError[];
 
 // https://github.com/import-js/eslint-plugin-import/issues/3019
 
@@ -32,9 +35,7 @@ export function getAST(cssText: string) {
     parseAtrulePrelude: false,
     parseCustomProperty: true,
     onParseError: (err) => {
-      const errorPrelude =
-        'Invalid CSS could not be parsed. CSS Anchor Positioning Polyfill was not applied.\n\n';
-      throw new Error(errorPrelude + err.formattedMessage, { cause: err });
+      cssParseErrors.push(err);
     },
   });
 }

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,6 +1,6 @@
 import type * as csstree from 'css-tree';
 
-import { getAST, splitCommaList } from '../../src/utils.js';
+import { cssParseErrors, getAST, splitCommaList } from '../../src/utils.js';
 
 describe('splitCommaList', () => {
   it('works', () => {
@@ -21,22 +21,23 @@ describe('splitCommaList', () => {
   });
 });
 describe('getAST', () => {
+  beforeEach(() => {
+    cssParseErrors.clear();
+  });
   it('parses valid CSS', () => {
     const cssText = 'a { color: red; }';
     const ast = getAST(cssText);
     expect(ast.type).toBe('StyleSheet');
   });
 
-  it('throws on invalid declaration', () => {
+  it('stores cssParseError on invalid declaration', () => {
     const cssText = 'a { color; red; } ';
-    expect(() => getAST(cssText)).toThrowError(
-      /Invalid CSS could not be parsed/,
-    );
+    getAST(cssText, true);
+    expect(cssParseErrors.size).toBe(2);
   });
-  it('throws on invalid selector', () => {
+  it('stores cssParseError on invalid selector', () => {
     const cssText = 'a-[1] { color: red; } ';
-    expect(() => getAST(cssText)).toThrowError(
-      /Invalid CSS could not be parsed/,
-    );
+    getAST(cssText, true);
+    expect(cssParseErrors.size).toBe(1);
   });
 });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -20,3 +20,23 @@ describe('splitCommaList', () => {
     ]);
   });
 });
+describe('getAST', () => {
+  it('parses valid CSS', () => {
+    const cssText = 'a { color: red; }';
+    const ast = getAST(cssText);
+    expect(ast.type).toBe('StyleSheet');
+  });
+
+  it('throws on invalid declaration', () => {
+    const cssText = 'a { color; red; } ';
+    expect(() => getAST(cssText)).toThrowError(
+      /Invalid CSS could not be parsed/,
+    );
+  });
+  it('throws on invalid selector', () => {
+    const cssText = 'a-[1] { color: red; } ';
+    expect(() => getAST(cssText)).toThrowError(
+      /Invalid CSS could not be parsed/,
+    );
+  });
+});


### PR DESCRIPTION
## Description
Invalid selectors, for instance `.w-[10]`, crash the polyfill. This PR throws a more specific error to guide the developer in fixing it. It does not attempt to ignore or fix the error. 

There may be other places where invalid CSS will break the polyfill's assumption of validity, and we could use a similar approach as they are reported.

## Related Issue(s)
Closes #335 

## Steps to test/reproduce
Locally, add a rule with a selector like `.w-[10]` that is invalid, and see that the error is thrown.

Or, view console at https://codepen.io/jamessw/pen/GgJdEeM

