### PR TITLE
Add non-RCS styles for older browsers

### DIFF
--- a/public/demo.css
+++ b/public/demo.css
@@ -7,6 +7,14 @@ html {
   --brand-blue: lch(38.953% 23.391 229.55deg);
   --brand-pink: lch(50.161% 77.603 3.8969deg);
   --brand-orange: lch(70.149% 72.526 55.336deg);
+  --brand-pink-light: lch(50.161% 85.603 3.8969deg);
+  --brand-pink-dark: lch(50.161% 57.603 3.8969deg);
+  --brand-orange-dark: lch(50.149% 72.526 55.336deg);
+  --gray-1: lch(91% 4.391 229.55deg);
+  --gray-2: lch(52.953% 4.391 229.55deg);
+  --gray-3: lch(42.953% 10.391 229.55deg);
+  --gray-4: lch(25.953% 10.391 229.55deg);
+  --gray-5: lch(12.953% 10.391 229.55deg);
 
   @supports (color: lch(from white l c h)) {
     --brand-pink-light: lch(from var(--brand-pink) calc(l + 8) c h);
@@ -17,18 +25,6 @@ html {
     --gray-3: lch(from var(--brand-blue) calc(l + 4) calc(c - 13) h);
     --gray-4: lch(from var(--brand-blue) calc(l - 13) calc(c - 13) h);
     --gray-5: lch(from var(--brand-blue) calc(l - 26) calc(c - 13) h);
-  }
-
-  @supports not (color: lch(from white l c h)) {
-    --brand-pink-light: lch(50.161% 85.603 3.8969deg);
-    --brand-pink-dark: lch(50.161% 57.603 3.8969deg);
-    --brand-orange: lch(70.149% 72.526 55.336deg);
-    --brand-orange-dark: lch(50.149% 72.526 55.336deg);
-    --gray-1: lch(91% 4.391 229.55deg);
-    --gray-2: lch(52.953% 4.391 229.55deg);
-    --gray-3: lch(42.953% 10.391 229.55deg);
-    --gray-4: lch(25.953% 10.391 229.55deg);
-    --gray-5: lch(12.953% 10.391 229.55deg);
   }
 
   --action: var(--brand-pink-dark);


### PR DESCRIPTION
## Description
Since the polyfill is used in older browsers, we need to support browsers that don't have relative color syntax. Most notablt, the "Apply polyfill" button was not visible.

## Related Issue(s)
Fixes #321 


## Show me

### Before
<img width="1738" height="1005" alt="image" src="https://github.com/user-attachments/assets/7e537f0a-4c09-4098-950c-511d5e7828f5" />


### After
<img width="1755" height="1004" alt="image" src="https://github.com/user-attachments/assets/065af7c7-6b86-4265-b211-10faf5998c34" />
