### PR TITLE
Support CSS anchor positioning in constructed stylesheets (`adoptedStyleSheets`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ dedicated shadow entrypoint **before** any custom element's `connectedCallback` 
 
 ```html
 <script type="module">
-  if (!("anchorName" in document.documentElement.style)) {
-    await import("https://unpkg.com/@oddbird/css-anchor-positioning/dist/css-anchor-positioning-shadow.js");
+  if (!('anchorName' in document.documentElement.style)) {
+    await import('https://unpkg.com/@oddbird/css-anchor-positioning/dist/css-anchor-positioning-shadow.js');
     // Define your custom elements after the entrypoint has loaded
   }
 </script>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,32 @@ import polyfill from '@oddbird/css-anchor-positioning/fn';
 The `polyfill` function returns a promise that resolves when the polyfill has
 been applied.
 
+### Constructed stylesheets (`adoptedStyleSheets`)
+
+If your custom elements use [constructed stylesheets](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet)
+(via `new CSSStyleSheet()` + `replaceSync()` + `shadowRoot.adoptedStyleSheets`), load the
+dedicated shadow entrypoint **before** any custom element's `connectedCallback` runs:
+
+```html
+<script type="module">
+  if (!("anchorName" in document.documentElement.style)) {
+    await import("https://unpkg.com/@oddbird/css-anchor-positioning/dist/css-anchor-positioning-shadow.js");
+    // Define your custom elements after the entrypoint has loaded
+  }
+</script>
+```
+
+With a bundler:
+
+```js
+import '@oddbird/css-anchor-positioning/shadow';
+```
+
+This entrypoint patches `CSSStyleSheet.prototype.replaceSync` to capture
+stylesheet source text, and patches the `ShadowRoot.prototype.adoptedStyleSheets`
+setter to automatically run the polyfill for each shadow root once its host
+element's `connectedCallback` finishes.
+
 You can view a more complete demo
 [here](https://anchor-positioning.oddbird.net/).
 
@@ -162,8 +188,6 @@ following features:
 - `position-visibility` property
 - dynamically added/removed anchors or targets
 - anchors and targets in separate shadow roots (see https://github.com/oddbird/css-anchor-positioning/issues/191)
-- anchors or targets in constructed stylesheets
-  (https://github.com/oddbird/css-anchor-positioning/issues/228)
 - vertical/rtl writing-modes for anchor functions (partial support)
 - implicit anchors or the `position-anchor: auto` keyword (pending resolution of
   https://github.com/whatwg/html/pull/9144)

--- a/package.json
+++ b/package.json
@@ -33,12 +33,20 @@
       "types": "./dist/index-fn.d.ts",
       "import": "./dist/css-anchor-positioning-fn.js",
       "require": "./dist/css-anchor-positioning-fn.umd.cjs"
+    },
+    "./shadow": {
+      "types": "./dist/index-shadow.d.ts",
+      "import": "./dist/css-anchor-positioning-shadow.js",
+      "require": "./dist/css-anchor-positioning-shadow.umd.cjs"
     }
   },
   "typesVersions": {
     "*": {
       "fn": [
         "./dist/index-fn.d.ts"
+      ],
+      "shadow": [
+        "./dist/index-shadow.d.ts"
       ]
     }
   },
@@ -52,6 +60,7 @@
     "build": "run-s build:demo build:dist build:fn",
     "build:dist": "vite build",
     "build:fn": "cross-env BUILD_FN=1 vite build",
+    "build:shadow": "cross-env BUILD_SHADOW=1 vite build",
     "build:wpt": "cross-env BUILD_WPT=1 vite build",
     "build:demo": "cross-env BUILD_DEMO=1 vite build",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "run-s build:demo build:dist build:fn",
+    "build": "run-s build:demo build:dist build:fn build:shadow",
     "build:dist": "vite build",
     "build:fn": "cross-env BUILD_FN=1 vite build",
     "build:shadow": "cross-env BUILD_SHADOW=1 vite build",

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -23,7 +23,8 @@
     </script>
     <link rel="stylesheet" href="/demo.css" />
     <style>
-      anchor-web-component {
+      anchor-web-component,
+      anchor-adopted-styles {
         width: 100%;
       }
     </style>
@@ -37,13 +38,14 @@
 
       if (!SUPPORTS_ANCHOR_POSITIONING) {
         btn.addEventListener('click', () => {
-          document
-            .querySelector('anchor-web-component')
-            .applyPolyfill()
-            .then(() => {
-              btn.innerText = 'Polyfill Applied';
-              btn.setAttribute('disabled', '');
-            });
+          const roots = [
+            document.querySelector('anchor-web-component').shadowRoot,
+            document.querySelector('anchor-adopted-styles').shadowRoot,
+          ];
+          polyfill({ roots }).then(() => {
+            btn.innerText = 'Polyfill Applied';
+            btn.setAttribute('disabled', '');
+          });
         });
       } else {
         btn.innerText = 'No Polyfill Needed';
@@ -53,13 +55,36 @@
         );
       }
 
-      class AnchorWebComponent extends HTMLElement {
-        /* This would typically be run in connectedCallback() */
-        applyPolyfill() {
-          return polyfill({ roots: [this.shadowRoot] });
+      class AnchorWebComponent extends HTMLElement {}
+      customElements.define('anchor-web-component', AnchorWebComponent);
+
+      class AnchorAdoptedStyles extends HTMLElement {
+        connectedCallback() {
+          this.attachShadow({ mode: 'open' });
+
+          const sheet = new CSSStyleSheet();
+          sheet.replaceSync(`
+            .anchor {
+              anchor-name: --adopted-anchor;
+            }
+            .target {
+              position: absolute;
+              right: anchor(--adopted-anchor right, 50px);
+              top: anchor(--adopted-anchor bottom);
+            }
+          `);
+          this.shadowRoot.adoptedStyleSheets = [sheet];
+
+          this.shadowRoot.innerHTML = `
+            <link rel="stylesheet" href="/demo.css" />
+            <div style="position: relative">
+              <div class="target">Target</div>
+              <div class="anchor">Anchor</div>
+            </div>
+          `;
         }
       }
-      customElements.define('anchor-web-component', AnchorWebComponent);
+      customElements.define('anchor-adopted-styles', AnchorAdoptedStyles);
     </script>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <script src="https://unpkg.com/prismjs@v1.x/components/prism-core.min.js"></script>
@@ -167,6 +192,57 @@ class AnchorDemo extends HTMLElement {
   }
 }
 customElements.define("anchor-web-component", AnchorDemo);
+&lt;/script&gt;
+</code></pre>
+    </section>
+    <section id="adopted-stylesheets" class="demo-item">
+      <h2>
+        <a href="#adopted-stylesheets" aria-hidden="true">🔗</a>
+        Works with adopted stylesheets (constructed CSSStyleSheet)
+      </h2>
+      <div class="demo-elements">
+        <anchor-adopted-styles></anchor-adopted-styles>
+      </div>
+      <div class="note">
+        <p>
+          With polyfill applied: Target and Anchor's right edges line up.
+          Target's top edge lines up with the bottom edge of the Anchor.
+        </p>
+        <p>
+          This demo uses <code>new CSSStyleSheet()</code> with
+          <code>replaceSync()</code>, added to the shadow root via
+          <code>adoptedStyleSheets</code>.
+        </p>
+      </div>
+
+      <pre><code class="language-html"
+>&lt;anchor-adopted-styles&gt;&lt;/anchor-adopted-styles&gt;
+&lt;script&gt;
+class AnchorAdoptedStyles extends HTMLElement {
+  connectedCallback() {
+    this.attachShadow({ mode: "open" });
+
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(`
+      .anchor {
+        anchor-name: --adopted-anchor;
+      }
+      .target {
+        position: absolute;
+        right: anchor(--adopted-anchor right, 50px);
+        top: anchor(--adopted-anchor bottom);
+      }
+    `);
+    this.shadowRoot.adoptedStyleSheets = [sheet];
+
+    this.shadowRoot.innerHTML = `
+      &lt;div style="position: relative"&gt;
+        &lt;div class="target"&gt;Target&lt;/div&gt;
+        &lt;div class="anchor"&gt;Anchor&lt;/div&gt;
+      &lt;/div&gt;
+    `;
+  }
+}
 &lt;/script&gt;
 </code></pre>
     </section>

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -91,6 +91,7 @@
             location.hash = 'apply-polyfill';
             location.reload();
           });
+          defineCustomElements();
         }
       } else {
         btn.innerText = 'No Polyfill Needed';

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -29,68 +29,78 @@
       }
     </style>
     <script type="module">
-      import polyfill from '/src/index-fn.ts';
+      function defineCustomElements() {
+        class AnchorWebComponent extends HTMLElement {}
+        customElements.define('anchor-web-component', AnchorWebComponent);
+
+        class AnchorAdoptedStyles extends HTMLElement {
+          connectedCallback() {
+            this.attachShadow({ mode: 'open' });
+
+            const sheet = new CSSStyleSheet();
+            sheet.replaceSync(`
+              .anchor {
+                anchor-name: --adopted-anchor;
+              }
+              .target {
+                position: absolute;
+                right: anchor(--adopted-anchor right, 50px);
+                top: anchor(--adopted-anchor bottom);
+              }
+            `);
+            this.shadowRoot.adoptedStyleSheets = [sheet];
+
+            this.shadowRoot.innerHTML = `
+              <link rel="stylesheet" href="/demo.css" />
+              <div style="position: relative">
+                <div class="target">Target</div>
+                <div class="anchor">Anchor</div>
+              </div>
+            `;
+          }
+        }
+        customElements.define('anchor-adopted-styles', AnchorAdoptedStyles);
+      }
+
+      const btn = document.getElementById('apply-polyfill');
 
       const SUPPORTS_ANCHOR_POSITIONING =
         'anchorName' in document.documentElement.style;
 
-      const btn = document.getElementById('apply-polyfill');
-
       if (!SUPPORTS_ANCHOR_POSITIONING) {
-        const shouldApply = location.hash === '#apply-polyfill';
+        if (location.hash === '#apply-polyfill') {
+          // Load the shadow entrypoint first so the `replaceSync` and
+          // `adoptedStyleSheets` patches are installed before any custom
+          // element's `connectedCallback` runs.
+          const { default: polyfill } = await import('/src/index-shadow.ts');
 
-        if (shouldApply) {
-          const roots = [
-            document.querySelector('anchor-web-component').shadowRoot
-          ];
-          polyfill({ roots }).then(() => {
-            btn.innerText = 'Polyfill Applied';
-            btn.setAttribute('disabled', '');
+          // Now define the custom elements
+          defineCustomElements();
+
+          // Load the polyfill explicitly for the <anchor-web-component> demo.
+          // The <anchor-adopted-styles> is already covered by the adopted
+          // stylesheet patch.
+          await polyfill({
+            roots: [document.querySelector('anchor-web-component').shadowRoot]
+          });
+
+          btn.innerText = 'Polyfill Applied';
+          btn.setAttribute('disabled', '');
+        } else {
+          btn.addEventListener('click', () => {
+            location.hash = 'apply-polyfill';
+            location.reload();
           });
         }
-
-        btn.addEventListener('click', () => {
-          location.hash = 'apply-polyfill';
-          location.reload();
-        });
       } else {
         btn.innerText = 'No Polyfill Needed';
         btn.setAttribute('disabled', '');
         console.log(
           'anchor-positioning is supported in this browser; polyfill skipped.',
         );
+
+        defineCustomElements();
       }
-
-      class AnchorWebComponent extends HTMLElement {}
-      customElements.define('anchor-web-component', AnchorWebComponent);
-
-      class AnchorAdoptedStyles extends HTMLElement {
-        connectedCallback() {
-          this.attachShadow({ mode: 'open' });
-
-          const sheet = new CSSStyleSheet();
-          sheet.replaceSync(`
-            .anchor {
-              anchor-name: --adopted-anchor;
-            }
-            .target {
-              position: absolute;
-              right: anchor(--adopted-anchor right, 50px);
-              top: anchor(--adopted-anchor bottom);
-            }
-          `);
-          this.shadowRoot.adoptedStyleSheets = [sheet];
-
-          this.shadowRoot.innerHTML = `
-            <link rel="stylesheet" href="/demo.css" />
-            <div style="position: relative">
-              <div class="target">Target</div>
-              <div class="anchor">Anchor</div>
-            </div>
-          `;
-        }
-      }
-      customElements.define('anchor-adopted-styles', AnchorAdoptedStyles);
     </script>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <script src="https://unpkg.com/prismjs@v1.x/components/prism-core.min.js"></script>
@@ -222,7 +232,12 @@ customElements.define("anchor-web-component", AnchorDemo);
       </div>
 
       <pre><code class="language-html"
->&lt;anchor-adopted-styles&gt;&lt;/anchor-adopted-styles&gt;
+>&lt;!-- Load the shadow entrypoint before defining custom elements,
+so the replaceSync and adoptedStyleSheets patches are installed
+before any connectedCallback runs. --&gt;
+&lt;script type="module" src="/dist/css-anchor-positioning-shadow.js"&gt;&lt;/script&gt;
+
+&lt;anchor-adopted-styles&gt;&lt;/anchor-adopted-styles&gt;
 &lt;script&gt;
 class AnchorAdoptedStyles extends HTMLElement {
   connectedCallback() {

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -41,8 +41,7 @@
 
         if (shouldApply) {
           const roots = [
-            document.querySelector('anchor-web-component').shadowRoot,
-            document.querySelector('anchor-adopted-styles').shadowRoot,
+            document.querySelector('anchor-web-component').shadowRoot
           ];
           polyfill({ roots }).then(() => {
             btn.innerText = 'Polyfill Applied';

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -81,7 +81,7 @@
           // The <anchor-adopted-styles> is already covered by the adopted
           // stylesheet patch.
           await polyfill({
-            roots: [document.querySelector('anchor-web-component').shadowRoot]
+            roots: [document.querySelector('anchor-web-component').shadowRoot],
           });
 
           btn.innerText = 'Polyfill Applied';

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -91,7 +91,6 @@
             location.hash = 'apply-polyfill';
             location.reload();
           });
-          defineCustomElements();
         }
       } else {
         btn.innerText = 'No Polyfill Needed';
@@ -178,7 +177,8 @@
         </p>
         <p>
           <strong>Note: </strong> this will not work across shadow root
-          boundaries, and will not work with constructed stylesheets.
+          boundaries. See the <a href="#adopted-stylesheets">next demo</a> for
+          an example of how to use the polyfill with adopted stylesheets.
         </p>
       </div>
 

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -37,7 +37,9 @@
       const btn = document.getElementById('apply-polyfill');
 
       if (!SUPPORTS_ANCHOR_POSITIONING) {
-        btn.addEventListener('click', () => {
+        const shouldApply = location.hash === '#apply-polyfill';
+
+        if (shouldApply) {
           const roots = [
             document.querySelector('anchor-web-component').shadowRoot,
             document.querySelector('anchor-adopted-styles').shadowRoot,
@@ -46,6 +48,11 @@
             btn.innerText = 'Polyfill Applied';
             btn.setAttribute('disabled', '');
           });
+        }
+
+        btn.addEventListener('click', () => {
+          location.hash = 'apply-polyfill';
+          location.reload();
         });
       } else {
         btn.innerText = 'No Polyfill Needed';

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -118,7 +118,6 @@ function fetchAdoptedStyleSheets(roots: AnchorPositioningRoot[]) {
       }
       seen.add(sheet);
       adoptedStyles.push({
-        el: null as unknown as HTMLElement,
         css: getAdoptedStylesheetText(sheet),
         sheet,
       });

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,8 +1,11 @@
 import { nanoid } from 'nanoid/non-secure';
 
 import { querySelectorAllRoots } from './dom.js';
-import { type NormalizedAnchorPositioningPolyfillOptions } from './polyfill.js';
-import { type StyleData } from './utils.js';
+import {
+  type AnchorPositioningRoot,
+  type NormalizedAnchorPositioningPolyfillOptions,
+} from './polyfill.js';
+import { getAdoptedStylesheetText, type StyleData } from './utils.js';
 
 const INVALID_MIME_TYPE_ERROR = 'InvalidMimeType';
 
@@ -97,6 +100,33 @@ function fetchInlineStyles(elements?: HTMLElement[]) {
   return inlineStyles;
 }
 
+// Collects constructed stylesheets that have been adopted (via
+// `adoptedStyleSheets`) on any of the given roots. The source text captured
+// when the stylesheet was constructed (or its serialized rules as a fallback)
+// is used so the styles can be re-parsed and transformed by the polyfill.
+function fetchAdoptedStyleSheets(roots: AnchorPositioningRoot[]) {
+  const adoptedStyles: Partial<StyleData>[] = [];
+  const seen = new Set<CSSStyleSheet>();
+  for (const root of roots) {
+    const sheets = (root as Document | ShadowRoot).adoptedStyleSheets;
+    if (!sheets) {
+      continue;
+    }
+    for (const sheet of sheets) {
+      if (seen.has(sheet)) {
+        continue;
+      }
+      seen.add(sheet);
+      adoptedStyles.push({
+        el: null as unknown as HTMLElement,
+        css: getAdoptedStylesheetText(sheet),
+        sheet,
+      });
+    }
+  }
+  return adoptedStyles;
+}
+
 export async function fetchCSS(
   options: NormalizedAnchorPositioningPolyfillOptions,
 ): Promise<StyleData[]> {
@@ -124,5 +154,12 @@ export async function fetchCSS(
 
   const inlines = fetchInlineStyles(elementsForInlines);
 
-  return await fetchLinkedStylesheets([...sources, ...inlines]);
+  // Collect constructed stylesheets adopted on the polyfill roots. Skipped when
+  // an explicit `elements` list is provided, as that opts into element-only
+  // polyfilling.
+  const adopted = options.elements
+    ? []
+    : fetchAdoptedStyleSheets(options.roots);
+
+  return await fetchLinkedStylesheets([...sources, ...inlines, ...adopted]);
 }

--- a/src/index-shadow.ts
+++ b/src/index-shadow.ts
@@ -1,0 +1,6 @@
+import { polyfill } from './polyfill.js';
+import { installConstructedStylesheetPatches } from './shadow.js';
+
+installConstructedStylesheetPatches();
+
+export default polyfill;

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -32,17 +32,109 @@ import {
   type SizingProperty,
 } from './syntax.js';
 import { transformCSS } from './transform.js';
-import { reportParseErrorsOnFailure, resetParseErrors } from './utils.js';
+import {
+  captureAdoptedStylesheetText,
+  originalReplaceSync,
+  reportParseErrorsOnFailure,
+  resetParseErrors,
+  type StyleData,
+} from './utils.js';
 
 const platformWithCache = { ...platform, _c: new Map() };
-
-const originalReplaceSync = CSSStyleSheet.prototype.replaceSync;
 
 const adoptedStyleSheetsDescriptor = Object.getOwnPropertyDescriptor(
   ShadowRoot.prototype,
   'adoptedStyleSheets',
-)!;
-const originalAdoptedStyleSheetsSet = adoptedStyleSheetsDescriptor.set!;
+);
+const originalAdoptedStyleSheetsSet = adoptedStyleSheetsDescriptor?.set;
+
+// Patch `replaceSync` and the `adoptedStyleSheets` setter as soon as this
+// module is loaded. This must happen before any custom element's
+// `connectedCallback` constructs a stylesheet or adopts it into a shadow root,
+// otherwise those styles would be missed by the polyfill.
+function installConstructedStylesheetPatches() {
+  // Patch `replaceSync` to capture the source text of constructed stylesheets
+  // and immediately cascade unsupported properties into custom properties, so
+  // the styles take effect as soon as the stylesheet is constructed. The
+  // original (untransformed) text is captured so the polyfill can later
+  // re-parse it to resolve `anchor()` functions.
+  if (CSSStyleSheet.prototype.replaceSync === originalReplaceSync) {
+    CSSStyleSheet.prototype.replaceSync = function (text: string) {
+      captureAdoptedStylesheetText(this, text);
+      const styleData: StyleData = {
+        el: null as unknown as HTMLElement,
+        css: text,
+      };
+      const cascadeCausedChanges = cascadeCSS([styleData]);
+      return originalReplaceSync.call(
+        this,
+        cascadeCausedChanges ? styleData.css : text,
+      );
+    };
+  }
+
+  // Patch the `adoptedStyleSheets` setter so that anchors/targets styled by
+  // constructed stylesheets get positioned. We have access to the `ShadowRoot`
+  // here (`this`), but the shadow root's children may not exist yet (e.g. when
+  // `adoptedStyleSheets` is assigned before `innerHTML` in `connectedCallback`).
+  // To position only after the shadow DOM is populated, we wrap the host
+  // element's `connectedCallback` and run the polyfill for the shadow root once
+  // the (original) callback has finished.
+  if (
+    adoptedStyleSheetsDescriptor &&
+    originalAdoptedStyleSheetsSet &&
+    adoptedStyleSheetsDescriptor.set === originalAdoptedStyleSheetsSet
+  ) {
+    Object.defineProperty(ShadowRoot.prototype, 'adoptedStyleSheets', {
+      ...adoptedStyleSheetsDescriptor,
+      set(this: ShadowRoot, sheets: CSSStyleSheet[]) {
+        originalAdoptedStyleSheetsSet.call(this, sheets);
+        if (sheets.length > 0) {
+          patchHostConnectedCallback(this);
+        }
+      },
+    });
+  }
+}
+
+// Marks host elements whose `connectedCallback` has already been wrapped, so we
+// don't wrap it more than once if multiple stylesheets are adopted.
+const patchedHosts = new WeakSet<HTMLElement>();
+
+interface CustomElementHost extends HTMLElement {
+  connectedCallback?: () => void;
+}
+
+/**
+ * Wraps the `connectedCallback` of a shadow root's host element so that, after
+ * the original callback runs (and the shadow DOM is populated), the polyfill is
+ * run for that shadow root to position its anchored elements.
+ */
+function patchHostConnectedCallback(shadowRoot: ShadowRoot) {
+  const host = shadowRoot.host as CustomElementHost;
+  if (patchedHosts.has(host)) {
+    return;
+  }
+  patchedHosts.add(host);
+
+  const originalConnectedCallback = host.connectedCallback;
+  host.connectedCallback = function (this: CustomElementHost) {
+    originalConnectedCallback?.call(this);
+    void polyfill({ roots: [shadowRoot] });
+  };
+
+  // If the host is already connected (e.g. `adoptedStyleSheets` was assigned
+  // from within the host's `connectedCallback`), the wrapper above won't run
+  // for the current connection, so run the polyfill once the current callback
+  // has finished and the shadow DOM has been populated.
+  if (host.isConnected) {
+    queueMicrotask(() => {
+      void polyfill({ roots: [shadowRoot] });
+    });
+  }
+}
+
+installConstructedStylesheetPatches();
 
 export const resolveLogicalSideKeyword = (side: AnchorSide, rtl: boolean) => {
   let percentage: number | undefined;
@@ -633,36 +725,6 @@ export async function polyfill(
     useAnimationFrameOrOption ?? window.ANCHOR_POSITIONING_POLYFILL_OPTIONS,
   );
 
-  // Patch `replaceSync` to capture styles from constructed stylesheets
-  if (CSSStyleSheet.prototype.replaceSync === originalReplaceSync) {
-    CSSStyleSheet.prototype.replaceSync = function (text: string) {
-      const styleData = {
-        el: null as unknown as HTMLElement,
-        css: text,
-      };
-
-      const cascadeCausedChanges = cascadeCSS([styleData]);
-
-      console.log('this', this);
-
-      console.log('Transformed CSS from', text, styleData.css);
-
-      return originalReplaceSync.call(this, cascadeCausedChanges ? styleData.css : text);
-    };
-  }
-
-  // Patch `adoptedStyleSheets` setter to track which sheets are adopted on each shadow root
-  if (adoptedStyleSheetsDescriptor.set === originalAdoptedStyleSheetsSet) {
-    Object.defineProperty(ShadowRoot.prototype, 'adoptedStyleSheets', {
-      ...adoptedStyleSheetsDescriptor,
-      set(sheets: CSSStyleSheet[]) {
-        console.log('Adding adopted stylesheets', this, sheets);
-
-        originalAdoptedStyleSheetsSet.call(this, sheets);
-      }
-    });
-  }
-
   // fetch CSS from stylesheet and inline style
   let styleData = await fetchCSS(options);
 
@@ -687,11 +749,6 @@ export async function polyfill(
     const parsedCSS = await parseCSS(styleData, { roots: options.roots });
     rules = parsedCSS.rules;
     inlineStyles = parsedCSS.inlineStyles;
-
-    console.log('rules', rules);
-    console.log('inlineStyles', inlineStyles);
-
-
   } catch (error) {
     reportParseErrorsOnFailure();
     throw error;

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -36,6 +36,14 @@ import { reportParseErrorsOnFailure, resetParseErrors } from './utils.js';
 
 const platformWithCache = { ...platform, _c: new Map() };
 
+const originalReplaceSync = CSSStyleSheet.prototype.replaceSync;
+
+const adoptedStyleSheetsDescriptor = Object.getOwnPropertyDescriptor(
+  ShadowRoot.prototype,
+  'adoptedStyleSheets',
+)!;
+const originalAdoptedStyleSheetsSet = adoptedStyleSheetsDescriptor.set!;
+
 export const resolveLogicalSideKeyword = (side: AnchorSide, rtl: boolean) => {
   let percentage: number | undefined;
   switch (side) {
@@ -625,6 +633,36 @@ export async function polyfill(
     useAnimationFrameOrOption ?? window.ANCHOR_POSITIONING_POLYFILL_OPTIONS,
   );
 
+  // Patch `replaceSync` to capture styles from constructed stylesheets
+  if (CSSStyleSheet.prototype.replaceSync === originalReplaceSync) {
+    CSSStyleSheet.prototype.replaceSync = function (text: string) {
+      const styleData = {
+        el: null as unknown as HTMLElement,
+        css: text,
+      };
+
+      const cascadeCausedChanges = cascadeCSS([styleData]);
+
+      console.log('this', this);
+
+      console.log('Transformed CSS from', text, styleData.css);
+
+      return originalReplaceSync.call(this, cascadeCausedChanges ? styleData.css : text);
+    };
+  }
+
+  // Patch `adoptedStyleSheets` setter to track which sheets are adopted on each shadow root
+  if (adoptedStyleSheetsDescriptor.set === originalAdoptedStyleSheetsSet) {
+    Object.defineProperty(ShadowRoot.prototype, 'adoptedStyleSheets', {
+      ...adoptedStyleSheetsDescriptor,
+      set(sheets: CSSStyleSheet[]) {
+        console.log('Adding adopted stylesheets', this, sheets);
+
+        originalAdoptedStyleSheetsSet.call(this, sheets);
+      }
+    });
+  }
+
   // fetch CSS from stylesheet and inline style
   let styleData = await fetchCSS(options);
 
@@ -649,6 +687,11 @@ export async function polyfill(
     const parsedCSS = await parseCSS(styleData, { roots: options.roots });
     rules = parsedCSS.rules;
     inlineStyles = parsedCSS.inlineStyles;
+
+    console.log('rules', rules);
+    console.log('inlineStyles', inlineStyles);
+
+
   } catch (error) {
     reportParseErrorsOnFailure();
     throw error;

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -33,108 +33,11 @@ import {
 } from './syntax.js';
 import { transformCSS } from './transform.js';
 import {
-  captureAdoptedStylesheetText,
-  originalReplaceSync,
   reportParseErrorsOnFailure,
   resetParseErrors,
-  type StyleData,
 } from './utils.js';
 
 const platformWithCache = { ...platform, _c: new Map() };
-
-const adoptedStyleSheetsDescriptor = Object.getOwnPropertyDescriptor(
-  ShadowRoot.prototype,
-  'adoptedStyleSheets',
-);
-const originalAdoptedStyleSheetsSet = adoptedStyleSheetsDescriptor?.set;
-
-// Patch `replaceSync` and the `adoptedStyleSheets` setter as soon as this
-// module is loaded. This must happen before any custom element's
-// `connectedCallback` constructs a stylesheet or adopts it into a shadow root,
-// otherwise those styles would be missed by the polyfill.
-function installConstructedStylesheetPatches() {
-  // Patch `replaceSync` to capture the source text of constructed stylesheets
-  // and immediately cascade unsupported properties into custom properties, so
-  // the styles take effect as soon as the stylesheet is constructed. The
-  // original (untransformed) text is captured so the polyfill can later
-  // re-parse it to resolve `anchor()` functions.
-  if (CSSStyleSheet.prototype.replaceSync === originalReplaceSync) {
-    CSSStyleSheet.prototype.replaceSync = function (text: string) {
-      captureAdoptedStylesheetText(this, text);
-      const styleData: StyleData = {
-        el: null as unknown as HTMLElement,
-        css: text,
-      };
-      const cascadeCausedChanges = cascadeCSS([styleData]);
-      return originalReplaceSync.call(
-        this,
-        cascadeCausedChanges ? styleData.css : text,
-      );
-    };
-  }
-
-  // Patch the `adoptedStyleSheets` setter so that anchors/targets styled by
-  // constructed stylesheets get positioned. We have access to the `ShadowRoot`
-  // here (`this`), but the shadow root's children may not exist yet (e.g. when
-  // `adoptedStyleSheets` is assigned before `innerHTML` in `connectedCallback`).
-  // To position only after the shadow DOM is populated, we wrap the host
-  // element's `connectedCallback` and run the polyfill for the shadow root once
-  // the (original) callback has finished.
-  if (
-    adoptedStyleSheetsDescriptor &&
-    originalAdoptedStyleSheetsSet &&
-    adoptedStyleSheetsDescriptor.set === originalAdoptedStyleSheetsSet
-  ) {
-    Object.defineProperty(ShadowRoot.prototype, 'adoptedStyleSheets', {
-      ...adoptedStyleSheetsDescriptor,
-      set(this: ShadowRoot, sheets: CSSStyleSheet[]) {
-        originalAdoptedStyleSheetsSet.call(this, sheets);
-        if (sheets.length > 0) {
-          patchHostConnectedCallback(this);
-        }
-      },
-    });
-  }
-}
-
-// Marks host elements whose `connectedCallback` has already been wrapped, so we
-// don't wrap it more than once if multiple stylesheets are adopted.
-const patchedHosts = new WeakSet<HTMLElement>();
-
-interface CustomElementHost extends HTMLElement {
-  connectedCallback?: () => void;
-}
-
-/**
- * Wraps the `connectedCallback` of a shadow root's host element so that, after
- * the original callback runs (and the shadow DOM is populated), the polyfill is
- * run for that shadow root to position its anchored elements.
- */
-function patchHostConnectedCallback(shadowRoot: ShadowRoot) {
-  const host = shadowRoot.host as CustomElementHost;
-  if (patchedHosts.has(host)) {
-    return;
-  }
-  patchedHosts.add(host);
-
-  const originalConnectedCallback = host.connectedCallback;
-  host.connectedCallback = function (this: CustomElementHost) {
-    originalConnectedCallback?.call(this);
-    void polyfill({ roots: [shadowRoot] });
-  };
-
-  // If the host is already connected (e.g. `adoptedStyleSheets` was assigned
-  // from within the host's `connectedCallback`), the wrapper above won't run
-  // for the current connection, so run the polyfill once the current callback
-  // has finished and the shadow DOM has been populated.
-  if (host.isConnected) {
-    queueMicrotask(() => {
-      void polyfill({ roots: [shadowRoot] });
-    });
-  }
-}
-
-installConstructedStylesheetPatches();
 
 export const resolveLogicalSideKeyword = (side: AnchorSide, rtl: boolean) => {
   let percentage: number | undefined;

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -32,10 +32,7 @@ import {
   type SizingProperty,
 } from './syntax.js';
 import { transformCSS } from './transform.js';
-import {
-  reportParseErrorsOnFailure,
-  resetParseErrors,
-} from './utils.js';
+import { reportParseErrorsOnFailure, resetParseErrors } from './utils.js';
 
 const platformWithCache = { ...platform, _c: new Map() };
 

--- a/src/shadow.ts
+++ b/src/shadow.ts
@@ -1,0 +1,88 @@
+import { polyfill } from './polyfill.js';
+import { captureAdoptedStylesheetText, originalReplaceSync } from './utils.js';
+
+interface CustomElementHost extends HTMLElement {
+  connectedCallback?: () => void;
+}
+
+// Marks host elements whose `connectedCallback` has already been wrapped, so we
+// don't wrap it more than once if multiple stylesheets are adopted.
+const patchedHosts = new WeakSet<HTMLElement>();
+
+/**
+ * Wraps the `connectedCallback` of a shadow root's host element so that, after
+ * the original callback runs (and the shadow DOM is populated), the polyfill is
+ * run for that shadow root to position its anchored elements.
+ */
+function patchHostConnectedCallback(shadowRoot: ShadowRoot) {
+  const host = shadowRoot.host as CustomElementHost;
+  if (patchedHosts.has(host)) {
+    return;
+  }
+  patchedHosts.add(host);
+
+  const originalConnectedCallback = host.connectedCallback;
+  host.connectedCallback = function (this: CustomElementHost) {
+    originalConnectedCallback?.call(this);
+    void polyfill({ roots: [shadowRoot] });
+  };
+
+  // If the host is already connected (e.g. `adoptedStyleSheets` was assigned
+  // from within the host's `connectedCallback`), the wrapper above won't run
+  // for the current connection, so run the polyfill once the current callback
+  // has finished and the shadow DOM has been populated.
+  if (host.isConnected) {
+    queueMicrotask(() => {
+      void polyfill({ roots: [shadowRoot] });
+    });
+  }
+}
+
+/**
+ * Installs patches on `CSSStyleSheet.prototype.replaceSync` and the
+ * `ShadowRoot.prototype.adoptedStyleSheets` setter to support CSS anchor
+ * positioning in constructed stylesheets adopted into shadow roots.
+ *
+ * Call this as early as possible — before any custom element's
+ * `connectedCallback` runs — so that constructed stylesheets are captured and
+ * their shadow roots are queued for positioning.
+ */
+export function installConstructedStylesheetPatches() {
+  // Patch `replaceSync` to capture the source text of constructed stylesheets
+  // so the polyfill can later re-parse it.
+  if (CSSStyleSheet.prototype.replaceSync === originalReplaceSync) {
+    CSSStyleSheet.prototype.replaceSync = function (text: string) {
+      captureAdoptedStylesheetText(this, text);
+      return originalReplaceSync.call(this, text);
+    };
+  }
+
+  const adoptedStyleSheetsDescriptor = Object.getOwnPropertyDescriptor(
+    ShadowRoot.prototype,
+    'adoptedStyleSheets',
+  );
+  const originalAdoptedStyleSheetsSet = adoptedStyleSheetsDescriptor?.set;
+
+  // Patch the `adoptedStyleSheets` setter so that anchors/targets styled by
+  // constructed stylesheets get positioned. We have access to the `ShadowRoot`
+  // here (`this`), but the shadow root's children may not exist yet (e.g. when
+  // `adoptedStyleSheets` is assigned before `innerHTML` in `connectedCallback`).
+  // To position only after the shadow DOM is populated, we wrap the host
+  // element's `connectedCallback` and run the polyfill for the shadow root once
+  // the (original) callback has finished.
+  if (
+    adoptedStyleSheetsDescriptor &&
+    originalAdoptedStyleSheetsSet &&
+    adoptedStyleSheetsDescriptor.set === originalAdoptedStyleSheetsSet
+  ) {
+    Object.defineProperty(ShadowRoot.prototype, 'adoptedStyleSheets', {
+      ...adoptedStyleSheetsDescriptor,
+      set(this: ShadowRoot, sheets: CSSStyleSheet[]) {
+        originalAdoptedStyleSheetsSet.call(this, sheets);
+        if (sheets.length > 0) {
+          patchHostConnectedCallback(this);
+        }
+      },
+    });
+  }
+}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,4 +1,4 @@
-import { type StyleData } from './utils.js';
+import { type StyleData, writeAdoptedStylesheet } from './utils.js';
 
 // This is a list of non-global attributes that apply to link elements but do
 // not apply to style elements. These should be removed when converting from a
@@ -27,10 +27,15 @@ export function transformCSS(
   cleanup = false,
 ) {
   const updatedStyleData: StyleData[] = [];
-  for (const { el, css, changed, created = false } of styleData) {
-    const updatedObject: StyleData = { el, css, changed: false };
+  for (const { el, css, changed, created = false, sheet } of styleData) {
+    const updatedObject: StyleData = { el, css, changed: false, sheet };
     if (changed) {
-      if (el.tagName.toLowerCase() === 'style') {
+      if (sheet) {
+        // Handle constructed stylesheets adopted via `adoptedStyleSheets`.
+        // Write the transformed CSS back into the sheet, bypassing the patched
+        // `replaceSync` so the original source text remains captured.
+        writeAdoptedStylesheet(sheet, css);
+      } else if (el.tagName.toLowerCase() === 'style') {
         // Handle inline stylesheets
         el.innerHTML = css;
       } else if (el instanceof HTMLLinkElement) {
@@ -84,7 +89,7 @@ export function transformCSS(
       }
     }
     // Remove no-longer-needed data-attribute
-    if (cleanup && el.hasAttribute('data-has-inline-styles')) {
+    if (cleanup && el?.hasAttribute('data-has-inline-styles')) {
       el.removeAttribute('data-has-inline-styles');
     }
     updatedStyleData.push(updatedObject);

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -35,7 +35,7 @@ export function transformCSS(
         // Write the transformed CSS back into the sheet, bypassing the patched
         // `replaceSync` so the original source text remains captured.
         writeAdoptedStylesheet(sheet, css);
-      } else if (el.tagName.toLowerCase() === 'style') {
+      } else if (el?.tagName.toLowerCase() === 'style') {
         // Handle inline stylesheets
         el.innerHTML = css;
       } else if (el instanceof HTMLLinkElement) {
@@ -69,7 +69,7 @@ export function transformCSS(
           document.head.insertAdjacentElement('beforeend', styleEl);
         }
         updatedObject.el = styleEl;
-      } else if (el.hasAttribute('data-has-inline-styles')) {
+      } else if (el?.hasAttribute('data-has-inline-styles')) {
         // Handle inline styles
         const attr = el.getAttribute('data-has-inline-styles');
         if (attr) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,7 +86,10 @@ export const adoptedSheetText = new WeakMap<CSSStyleSheet, string>();
  * Records the original CSS text passed to a constructed stylesheet's
  * `replaceSync`, so it can later be re-parsed by the polyfill.
  */
-export function captureAdoptedStylesheetText(sheet: CSSStyleSheet, text: string) {
+export function captureAdoptedStylesheetText(
+  sheet: CSSStyleSheet,
+  text: string,
+) {
   adoptedSheetText.set(sheet, text);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,7 +63,7 @@ export function getDeclarationValue(node: DeclarationWithValue) {
 }
 
 export interface StyleData {
-  el: HTMLElement;
+  el?: HTMLElement;
   css: string;
   url?: URL;
   changed?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,6 +68,49 @@ export interface StyleData {
   url?: URL;
   changed?: boolean;
   created?: boolean; // Whether the element is created by the polyfill
+  // The constructed stylesheet this data came from, when the styles were
+  // adopted via `adoptedStyleSheets` rather than a `<style>`/`<link>` element.
+  sheet?: CSSStyleSheet;
+}
+
+// Reference to the native `CSSStyleSheet.prototype.replaceSync` so that the
+// polyfill can write transformed CSS back into a constructed stylesheet without
+// re-triggering the patched version (which would re-capture the text).
+export const originalReplaceSync = CSSStyleSheet.prototype.replaceSync;
+
+// Maps a constructed stylesheet to the original (untransformed) CSS text that
+// was passed to `replaceSync`, so the polyfill can re-parse the source styles.
+export const adoptedSheetText = new WeakMap<CSSStyleSheet, string>();
+
+/**
+ * Records the original CSS text passed to a constructed stylesheet's
+ * `replaceSync`, so it can later be re-parsed by the polyfill.
+ */
+export function captureAdoptedStylesheetText(sheet: CSSStyleSheet, text: string) {
+  adoptedSheetText.set(sheet, text);
+}
+
+/**
+ * Serializes the current rules of a constructed stylesheet. Used as a fallback
+ * when the original `replaceSync` text was not captured (e.g. the sheet was
+ * populated before the polyfill patched `replaceSync`).
+ */
+export function getAdoptedStylesheetText(sheet: CSSStyleSheet) {
+  const captured = adoptedSheetText.get(sheet);
+  if (captured !== undefined) {
+    return captured;
+  }
+  return Array.from(sheet.cssRules)
+    .map((rule) => rule.cssText)
+    .join('\n');
+}
+
+/**
+ * Writes transformed CSS back into a constructed stylesheet, bypassing the
+ * patched `replaceSync` so the original source text remains captured.
+ */
+export function writeAdoptedStylesheet(sheet: CSSStyleSheet, css: string) {
+  originalReplaceSync.call(sheet, css);
 }
 
 export const POSITION_ANCHOR_PROPERTY = `--position-anchor-${INSTANCE_UUID}`;

--- a/tests/e2e/shadow-dom.test.ts
+++ b/tests/e2e/shadow-dom.test.ts
@@ -57,3 +57,25 @@ test('applies polyfill inside shadow root', async ({ page }) => {
   await expectWithinOne(target, 'top', parentHeight);
   await expectWithinOne(target, 'right', expected);
 });
+
+test('applies polyfill for adopted stylesheets in shadow root', async ({
+  page,
+}) => {
+  const anchorSelector = 'anchor-adopted-styles .anchor';
+  const targetSelector = 'anchor-adopted-styles .target';
+  const target = page.locator(targetSelector);
+  const width = await getElementWidth(page, anchorSelector);
+  const parentWidth = await getParentWidth(page, targetSelector);
+  const parentHeight = await getParentHeight(page, targetSelector);
+  const expected = parentWidth - width;
+
+  // Before the polyfill is applied, the `anchor()` values fall back to their
+  // defaults (`right: 50px`, `top` is unset).
+  await expect(target).toHaveCSS('right', '50px');
+
+  await applyPolyfill(page);
+
+  await expectWithinOne(target, 'top', parentHeight);
+  await expectWithinOne(target, 'right', expected);
+});
+

--- a/tests/e2e/shadow-dom.test.ts
+++ b/tests/e2e/shadow-dom.test.ts
@@ -78,4 +78,3 @@ test('applies polyfill for adopted stylesheets in shadow root', async ({
   await expectWithinOne(target, 'top', parentHeight);
   await expectWithinOne(target, 'right', expected);
 });
-

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,13 +35,21 @@ export default defineConfig({
                 // the proper extensions will be added
                 fileName: 'css-anchor-positioning-fn',
               }
-            : // build that runs the polyfill on import
-              {
-                entry: resolve(__dirname, 'src/index.ts'),
-                name: 'CssAnchorPositioning',
-                // the proper extensions will be added
-                fileName: 'css-anchor-positioning',
-              },
+            : process.env.BUILD_SHADOW
+              ? // build that installs the constructed-stylesheet patches on import
+                {
+                  entry: resolve(__dirname, 'src/index-shadow.ts'),
+                  name: 'CssAnchorPositioningShadow',
+                  // the proper extensions will be added
+                  fileName: 'css-anchor-positioning-shadow',
+                }
+              : // build that runs the polyfill on import
+                {
+                  entry: resolve(__dirname, 'src/index.ts'),
+                  name: 'CssAnchorPositioning',
+                  // the proper extensions will be added
+                  fileName: 'css-anchor-positioning',
+                },
         emptyOutDir: false,
         target: 'es6',
         sourcemap: true,
@@ -77,7 +85,7 @@ export default defineConfig({
       provider: 'istanbul',
       reporter: ['text-summary', 'html'],
       include: ['src/**/*.{js,ts}'],
-      exclude: ['src/index.ts', 'src/index-fn.ts', 'src/index-wpt.ts'],
+      exclude: ['src/index.ts', 'src/index-fn.ts', 'src/index-shadow.ts', 'src/index-wpt.ts'],
       skipFull: true,
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,7 +85,12 @@ export default defineConfig({
       provider: 'istanbul',
       reporter: ['text-summary', 'html'],
       include: ['src/**/*.{js,ts}'],
-      exclude: ['src/index.ts', 'src/index-fn.ts', 'src/index-shadow.ts', 'src/index-wpt.ts'],
+      exclude: [
+        'src/index.ts',
+        'src/index-fn.ts',
+        'src/index-shadow.ts',
+        'src/index-wpt.ts',
+      ],
       skipFull: true,
     },
   },


### PR DESCRIPTION
## Summary

Extends the polyfill to handle CSS anchor positioning defined in [constructed stylesheets](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) that are adopted into shadow roots via `adoptedStyleSheets`. This is the typical pattern for styles in custom elements using libraries like Lit.

## Architecture

Support is delivered as a **separate entrypoint** (`/shadow`) so it is opt-in and doesn't affect the bundle size of the default entrypoint. Users who need this feature import the shadow entrypoint in addition to (or instead of) the default one:

```html
<!-- Must be loaded before any custom element's connectedCallback runs -->
<script type="module" src="/dist/css-anchor-positioning-shadow.js"></script>
```

Or via npm:

```js
import 'css-anchor-positioning/shadow';
```

The entrypoint calls `installConstructedStylesheetPatches()` from the new `src/shadow.ts` module, which installs the required patches at module-evaluation time.

## How it works

### New files

- **`src/shadow.ts`** — contains all patching logic for constructed stylesheets
- **`src/index-shadow.ts`** — dedicated entrypoint; calls `installConstructedStylesheetPatches()` and re-exports `polyfill`

### Patches installed by `installConstructedStylesheetPatches()`

#### 1. `CSSStyleSheet.prototype.replaceSync`

The native `replaceSync` is patched to capture the original CSS text in a `WeakMap<CSSStyleSheet, string>` (`adoptedSheetText`) before passing it to the native implementation. This ensures the polyfill can later re-parse the untransformed source text via `fetchCSS`, even after the sheet has been updated with transformed CSS.

#### 2. `ShadowRoot.prototype.adoptedStyleSheets` setter

The setter is patched to call `patchHostConnectedCallback(shadowRoot)` whenever non-empty sheets are adopted. This wraps the host element's `connectedCallback` so that after the original callback runs (and the shadow DOM is fully populated), `polyfill({ roots: [shadowRoot] })` is invoked. Two timing cases are handled:

- **Sheets adopted before the host connects** — the wrapped `connectedCallback` fires on the next DOM connection.
- **Sheets adopted while the host is already connected** (e.g. from inside `connectedCallback`) — a `queueMicrotask` defers the polyfill run until after the current callback stack finishes, so that `innerHTML` and other DOM setup has completed.

A `WeakSet<HTMLElement>` (`patchedHosts`) ensures each host's callback is only wrapped once, even if multiple sheets are adopted.

### Changes to existing files

#### `src/utils.ts`

- `StyleData.el` is now optional (can be absent for stylesheet-backed entries)
- `StyleData.sheet?: CSSStyleSheet` — new optional field linking a `StyleData` entry to its constructed stylesheet
- `originalReplaceSync` — saved reference to the native `replaceSync` for write-back
- `adoptedSheetText` — `WeakMap` storing captured source CSS per sheet
- `captureAdoptedStylesheetText`, `getAdoptedStylesheetText`, `writeAdoptedStylesheet` — helpers used by `shadow.ts`, `fetch.ts`, and `transform.ts`

#### `src/fetch.ts`

New `fetchAdoptedStyleSheets` helper collects adopted `CSSStyleSheet` objects from each polyfill root, building `StyleData` entries (with a `sheet` reference and no `el`) using the captured source text (or serialized `cssRules` as a fallback). These are appended to the sources passed to `fetchLinkedStylesheets`. Skipped when `options.elements` is provided, since that opts into element-scoped polyfilling only.

#### `src/transform.ts`

- When a `StyleData` entry has a `sheet`, writes transformed CSS back into it via `writeAdoptedStylesheet` (which calls `originalReplaceSync` directly, bypassing the patch so the captured source text is not overwritten).
- Guards `el?.tagName`, `el?.hasAttribute`, and `el?.removeAttribute` calls with optional chaining, since `el` is now optional.

#### `vite.config.ts` / `package.json`

- New `build:shadow` script (`cross-env BUILD_SHADOW=1 vite build`) builds the shadow entrypoint
- New `./shadow` package export pointing to `dist/css-anchor-positioning-shadow.{js,umd.cjs,d.ts}`

### Demo (`shadow-dom.html`)

Updated to demonstrate the `adoptedStyleSheets` pattern:

- When `#apply-polyfill` is present in the URL hash, the shadow entrypoint is imported first, then custom element definitions are registered (so patches are in place before any `connectedCallback` runs).
- A new `<anchor-adopted-styles>` component demonstrates the full pattern using constructed stylesheets.

### Tests

A new e2e test (`tests/e2e/shadow-dom.test.ts`) verifies that anchored elements inside a shadow root styled via `adoptedStyleSheets` are correctly positioned after the polyfill runs.