### PR TITLE
Do not treeshake inline JS for demo

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,7 +60,25 @@ export default defineConfig({
           ],
         },
       },
-  plugins: [bundleStats({ compare: false, silent: true })],
+  plugins: [
+    // This package's `sideEffects` allowlist (in package.json) marks everything
+    // outside `src/index.ts` and the built files as side-effect-free, which is
+    // correct for consumers tree-shaking the library. But Rolldown (Vite 8+)
+    // also applies that allowlist to the demo HTML's inline
+    // `<script type="module">` modules, tree-shaking their top-level statements
+    // away and leaving the demo pages without any JavaScript. Mark those inline
+    // script modules as having side effects so the demo keeps working.
+    // See https://github.com/oddbird/css-anchor-positioning/issues/404
+    {
+      name: 'anchor-polyfill:demo-inline-script-side-effects',
+      transform(code, id) {
+        if (id.includes('html-proxy')) {
+          return { code, map: null, moduleSideEffects: 'no-treeshake' };
+        }
+      },
+    },
+    bundleStats({ compare: false, silent: true }),
+  ],
   /**
    * @see https://vitest.dev/config/#configuration
    */


### PR DESCRIPTION
Resolves #404 

The deployed demo pages were non-functional — the "Apply Polyfill" button did nothing — because the demo build dropped every inline `<script type="module">` entirely. Regressed with the Vite 7 → 8 upgrade (#391), which switched the bundler to **Rolldown**.

**Cause:** this package's `package.json` `sideEffects` allowlist marks everything outside `src/index.ts` + dist as side-effect-free (correct for consumers). Rolldown applies that same promise to the demo HTML's inline-script virtual modules (`index.html?html-proxy…`) and, trusting it, prunes the whole script body.

**Fix:** a small Vite plugin marks `html-proxy` modules as `moduleSideEffects: 'no-treeshake'`. The demo glue is preserved while the polyfill itself still tree-shakes exactly like the production build.

### Other approaches tried

- **`package.json` `sideEffects` globs** (`*.html`, `./index.html`, etc.) — the shaken module is the virtual `?html-proxy&index=N.js`, not the `.html` file; globs never match it (and it'd wrongly put demo concerns in the published package contract).
- **`treeshake.moduleSideEffects` function / rule-array** (the `.css` example from the [Rolldown docs](https://rolldown.rs/reference/InputOptions.treeshake#modulesideeffects)) — never consulted for our modules: `package.json` `sideEffects` already decides them, so Rolldown short-circuits.
- **`moduleSideEffects: true`** (vs `'no-treeshake'`) — insufficient; statements still pruned.
- **Side-effecting statements in the script** (`window.x = …`, `console.log(…)`) — still dropped; the module-level flag overrides any body analysis.
- **`treeshake: false`** — works, but blunt: disables tree-shaking for the polyfill too.

Opened https://github.com/vitejs/vite/issues/22620