### PR TITLE
Shadow DOM test fixes

### DIFF
--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -35,6 +35,7 @@
 
         class AnchorAdoptedStyles extends HTMLElement {
           connectedCallback() {
+            console.log('connected');
             this.attachShadow({ mode: 'open' });
 
             const sheet = new CSSStyleSheet();
@@ -91,6 +92,7 @@
             location.hash = 'apply-polyfill';
             location.reload();
           });
+          defineCustomElements();
         }
       } else {
         btn.innerText = 'No Polyfill Needed';

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -35,7 +35,6 @@
 
         class AnchorAdoptedStyles extends HTMLElement {
           connectedCallback() {
-            console.log('connected');
             this.attachShadow({ mode: 'open' });
 
             const sheet = new CSSStyleSheet();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,6 +81,7 @@ export interface StyleData {
 // stylesheet is being transformed, indicating the presence of CSSStyleSheet
 // support.
 export const originalReplaceSync =
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   globalThis.CSSStyleSheet?.prototype.replaceSync ?? (() => {});
 
 // Maps a constructed stylesheet to the original (untransformed) CSS text that

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,8 +75,13 @@ export interface StyleData {
 
 // Reference to the native `CSSStyleSheet.prototype.replaceSync` so that the
 // polyfill can write transformed CSS back into a constructed stylesheet without
-// re-triggering the patched version (which would re-capture the text).
-export const originalReplaceSync = CSSStyleSheet.prototype.replaceSync;
+// re-triggering the patched version (which would re-capture the text). In
+// environments without support for constructed stylesheets, fallback to a
+// no-op. This allows E2E tests to run, and is only called when a constructed
+// stylesheet is being transformed, indicating the presence of CSSStyleSheet
+// support.
+export const originalReplaceSync =
+  globalThis.CSSStyleSheet?.prototype.replaceSync ?? (() => {});
 
 // Maps a constructed stylesheet to the original (untransformed) CSS text that
 // was passed to `replaceSync`, so the polyfill can re-parse the source styles.

--- a/tests/e2e/shadow-dom.test.ts
+++ b/tests/e2e/shadow-dom.test.ts
@@ -64,14 +64,17 @@ test('applies polyfill for adopted stylesheets in shadow root', async ({
   const anchorSelector = 'anchor-adopted-styles .anchor';
   const targetSelector = 'anchor-adopted-styles .target';
   const target = page.locator(targetSelector);
+  const anchor = page.locator(anchorSelector);
   const width = await getElementWidth(page, anchorSelector);
   const parentWidth = await getParentWidth(page, targetSelector);
   const parentHeight = await getParentHeight(page, targetSelector);
   const expected = parentWidth - width;
 
-  // Before the polyfill is applied, the `anchor()` values fall back to their
-  // defaults (`right: 50px`, `top` is unset).
-  await expect(target).toHaveCSS('right', '50px');
+  // The empty value is `""`, so require more than one character.
+  const nonEmptyValue = /.+/;
+  // Before the polyfill is applied, anchor rules in adopted stylesheets are
+  // stripped out, and not present in the stylesheet at all.
+  await expect(anchor).not.toHaveCSS('anchor-name', nonEmptyValue);
 
   await applyPolyfill(page);
 


### PR DESCRIPTION
![](https://picsum.photos/600/400)

## Description
Initial parsing of the e2e tests was failing with the error `ReferenceError: CSSStyleSheet is not defined` - see
https://github.com/oddbird/css-anchor-positioning/actions/runs/27167277795/job/80197638199

I also adjusted shadow-dom.html to load the custom element on the initial page load, which enabled us to verify pre-polyfill behavior.

I missed this due to lint and tests not running for new contributors. When I ran locally, I missed that e2e tests fail silently on older versions of node.

@jpzwarte Could you take a look?