### PR TITLE
Move installConstructedStylesheetPatches to -fn entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ If your custom elements use [constructed stylesheets](https://developer.mozilla.
 ```html
 <script type="module">
   if (!('anchorName' in document.documentElement.style)) {
-    const { default: polyfill, patchAndPolyfillConstructedStylesheets } =
+    const { patchAndPolyfillConstructedStylesheets } =
       await import('https://unpkg.com/@oddbird/css-anchor-positioning/dist/css-anchor-positioning-fn.js');
     patchAndPolyfillConstructedStylesheets();
-    await polyfill();
-    // Define your custom elements after the polyfill has loaded
+    // Define your custom elements after the patch has applied the polyfill.
+    // You don't need to explicitly call polyfill().
   }
 </script>
 ```
@@ -83,7 +83,6 @@ import polyfill, {
 } from '@oddbird/css-anchor-positioning/fn';
 
 patchAndPolyfillConstructedStylesheets();
-polyfill();
 ```
 
 This patches `CSSStyleSheet.prototype.replaceSync` to capture

--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ If your custom elements use [constructed stylesheets](https://developer.mozilla.
 With a bundler:
 
 ```js
-import polyfill, {
-  patchAndPolyfillConstructedStylesheets,
-} from '@oddbird/css-anchor-positioning/fn';
+import { patchAndPolyfillConstructedStylesheets } from '@oddbird/css-anchor-positioning/fn';
 
 patchAndPolyfillConstructedStylesheets();
 ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ For build tools such as Vite, Webpack, and Parcel, that will look like this:
 
 ```js
 import polyfill from '@oddbird/css-anchor-positioning/fn';
+
+polyfill();
 ```
 
 The `polyfill` function returns a promise that resolves when the polyfill has
@@ -64,9 +66,11 @@ If your custom elements use [constructed stylesheets](https://developer.mozilla.
 ```html
 <script type="module">
   if (!('anchorName' in document.documentElement.style)) {
-    const { patchAndPolyfillConstructedStylesheets } =
+    const { default: polyfill, patchAndPolyfillConstructedStylesheets } =
       await import('https://unpkg.com/@oddbird/css-anchor-positioning/dist/css-anchor-positioning-fn.js');
-    // Define your custom elements after the entrypoint has loaded
+    patchAndPolyfillConstructedStylesheets();
+    await polyfill();
+    // Define your custom elements after the polyfill has loaded
   }
 </script>
 ```
@@ -74,7 +78,12 @@ If your custom elements use [constructed stylesheets](https://developer.mozilla.
 With a bundler:
 
 ```js
-import { patchAndPolyfillConstructedStylesheets } from '@oddbird/css-anchor-positioning/fn';
+import polyfill, {
+  patchAndPolyfillConstructedStylesheets,
+} from '@oddbird/css-anchor-positioning/fn';
+
+patchAndPolyfillConstructedStylesheets();
+polyfill();
 ```
 
 This patches `CSSStyleSheet.prototype.replaceSync` to capture

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ been applied.
 ### Constructed stylesheets (`adoptedStyleSheets`)
 
 If your custom elements use [constructed stylesheets](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet)
-(via `new CSSStyleSheet()` + `replaceSync()` + `shadowRoot.adoptedStyleSheets`), load the
-dedicated shadow entrypoint **before** any custom element's `connectedCallback` runs:
+(via `new CSSStyleSheet()` + `replaceSync()` + `shadowRoot.adoptedStyleSheets`), call `installConstructedStylesheetPatches()` **before** any custom element's `connectedCallback` runs:
 
 ```html
 <script type="module">
   if (!('anchorName' in document.documentElement.style)) {
-    await import('https://unpkg.com/@oddbird/css-anchor-positioning/dist/css-anchor-positioning-shadow.js');
+    const { installConstructedStylesheetPatches } =
+      await import('https://unpkg.com/@oddbird/css-anchor-positioning/dist/css-anchor-positioning-fn.js');
     // Define your custom elements after the entrypoint has loaded
   }
 </script>
@@ -74,16 +74,16 @@ dedicated shadow entrypoint **before** any custom element's `connectedCallback` 
 With a bundler:
 
 ```js
-import '@oddbird/css-anchor-positioning/shadow';
+import { installConstructedStylesheetPatches } from '@oddbird/css-anchor-positioning/fn';
 ```
 
-This entrypoint patches `CSSStyleSheet.prototype.replaceSync` to capture
+This patches `CSSStyleSheet.prototype.replaceSync` to capture
 stylesheet source text, and patches the `ShadowRoot.prototype.adoptedStyleSheets`
 setter to automatically run the polyfill for each shadow root once its host
 element's `connectedCallback` finishes.
 
 You can view a more complete demo
-[here](https://anchor-positioning.oddbird.net/).
+[here](https://anchor-positioning.oddbird.net/shadow-dom.html).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ been applied.
 ### Constructed stylesheets (`adoptedStyleSheets`)
 
 If your custom elements use [constructed stylesheets](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet)
-(via `new CSSStyleSheet()` + `replaceSync()` + `shadowRoot.adoptedStyleSheets`), call `installConstructedStylesheetPatches()` **before** any custom element's `connectedCallback` runs:
+(via `new CSSStyleSheet()` + `replaceSync()` + `shadowRoot.adoptedStyleSheets`), call `patchAndPolyfillConstructedStylesheets()` **before** any custom element's `connectedCallback` runs:
 
 ```html
 <script type="module">
   if (!('anchorName' in document.documentElement.style)) {
-    const { installConstructedStylesheetPatches } =
+    const { patchAndPolyfillConstructedStylesheets } =
       await import('https://unpkg.com/@oddbird/css-anchor-positioning/dist/css-anchor-positioning-fn.js');
     // Define your custom elements after the entrypoint has loaded
   }
@@ -74,7 +74,7 @@ If your custom elements use [constructed stylesheets](https://developer.mozilla.
 With a bundler:
 
 ```js
-import { installConstructedStylesheetPatches } from '@oddbird/css-anchor-positioning/fn';
+import { patchAndPolyfillConstructedStylesheets } from '@oddbird/css-anchor-positioning/fn';
 ```
 
 This patches `CSSStyleSheet.prototype.replaceSync` to capture

--- a/package.json
+++ b/package.json
@@ -33,20 +33,12 @@
       "types": "./dist/index-fn.d.ts",
       "import": "./dist/css-anchor-positioning-fn.js",
       "require": "./dist/css-anchor-positioning-fn.umd.cjs"
-    },
-    "./shadow": {
-      "types": "./dist/index-shadow.d.ts",
-      "import": "./dist/css-anchor-positioning-shadow.js",
-      "require": "./dist/css-anchor-positioning-shadow.umd.cjs"
     }
   },
   "typesVersions": {
     "*": {
       "fn": [
         "./dist/index-fn.d.ts"
-      ],
-      "shadow": [
-        "./dist/index-shadow.d.ts"
       ]
     }
   },
@@ -57,10 +49,9 @@
     "package.json"
   ],
   "scripts": {
-    "build": "run-s build:demo build:dist build:fn build:shadow",
+    "build": "run-s build:demo build:dist build:fn",
     "build:dist": "vite build",
     "build:fn": "cross-env BUILD_FN=1 vite build",
-    "build:shadow": "cross-env BUILD_SHADOW=1 vite build",
     "build:wpt": "cross-env BUILD_WPT=1 vite build",
     "build:demo": "cross-env BUILD_DEMO=1 vite build",
     "preview": "vite preview",

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -72,11 +72,11 @@
           // Load the shadow entrypoint first so the `replaceSync` and
           // `adoptedStyleSheets` patches are installed before any custom
           // element's `connectedCallback` runs.
-          const { default: polyfill, installConstructedStylesheetPatches } =
+          const { default: polyfill, patchAndPolyfillConstructedStylesheets } =
             await import('/src/index-fn.ts');
 
           // Patch Constructed stylesheets
-          installConstructedStylesheetPatches();
+          patchAndPolyfillConstructedStylesheets();
 
           // Now define the custom elements
           defineCustomElements();

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -72,7 +72,11 @@
           // Load the shadow entrypoint first so the `replaceSync` and
           // `adoptedStyleSheets` patches are installed before any custom
           // element's `connectedCallback` runs.
-          const { default: polyfill } = await import('/src/index-shadow.ts');
+          const { default: polyfill, installConstructedStylesheetPatches } =
+            await import('/src/index-fn.ts');
+
+          // Patch Constructed stylesheets
+          installConstructedStylesheetPatches();
 
           // Now define the custom elements
           defineCustomElements();

--- a/src/index-fn.ts
+++ b/src/index-fn.ts
@@ -1,3 +1,5 @@
 import { polyfill } from './polyfill.js';
 
+export { installConstructedStylesheetPatches } from './shadow.js';
+
 export default polyfill;

--- a/src/index-fn.ts
+++ b/src/index-fn.ts
@@ -1,5 +1,5 @@
 import { polyfill } from './polyfill.js';
 
-export { installConstructedStylesheetPatches } from './shadow.js';
+export { patchAndPolyfillConstructedStylesheets } from './shadow.js';
 
 export default polyfill;

--- a/src/index-shadow.ts
+++ b/src/index-shadow.ts
@@ -1,6 +1,0 @@
-import { polyfill } from './polyfill.js';
-import { installConstructedStylesheetPatches } from './shadow.js';
-
-installConstructedStylesheetPatches();
-
-export default polyfill;

--- a/src/shadow.ts
+++ b/src/shadow.ts
@@ -47,7 +47,7 @@ function patchHostConnectedCallback(shadowRoot: ShadowRoot) {
  * `connectedCallback` runs — so that constructed stylesheets are captured and
  * their shadow roots are queued for positioning.
  */
-export function installConstructedStylesheetPatches() {
+export function patchAndPolyfillConstructedStylesheets() {
   // Patch `replaceSync` to capture the source text of constructed stylesheets
   // so the polyfill can later re-parse it.
   if (CSSStyleSheet.prototype.replaceSync === originalReplaceSync) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -95,12 +95,7 @@ export default defineConfig({
       provider: 'istanbul',
       reporter: ['text-summary', 'html'],
       include: ['src/**/*.{js,ts}'],
-      exclude: [
-        'src/index.ts',
-        'src/index-fn.ts',
-        'src/index-shadow.ts',
-        'src/index-wpt.ts',
-      ],
+      exclude: ['src/index.ts', 'src/index-fn.ts', 'src/index-wpt.ts'],
       skipFull: true,
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,21 +35,13 @@ export default defineConfig({
                 // the proper extensions will be added
                 fileName: 'css-anchor-positioning-fn',
               }
-            : process.env.BUILD_SHADOW
-              ? // build that installs the constructed-stylesheet patches on import
-                {
-                  entry: resolve(__dirname, 'src/index-shadow.ts'),
-                  name: 'CssAnchorPositioningShadow',
-                  // the proper extensions will be added
-                  fileName: 'css-anchor-positioning-shadow',
-                }
-              : // build that runs the polyfill on import
-                {
-                  entry: resolve(__dirname, 'src/index.ts'),
-                  name: 'CssAnchorPositioning',
-                  // the proper extensions will be added
-                  fileName: 'css-anchor-positioning',
-                },
+            : // build that runs the polyfill on import
+              {
+                entry: resolve(__dirname, 'src/index.ts'),
+                name: 'CssAnchorPositioning',
+                // the proper extensions will be added
+                fileName: 'css-anchor-positioning',
+              },
         emptyOutDir: false,
         target: 'es6',
         sourcemap: true,


### PR DESCRIPTION
Removes the `index-shadow` entry, and moves the installConstructedStylesheetPatches function to the index-fn entry point. 

I'm also wondering about changing `installConstructedStylesheetPatches` to `patchAndPolyfillConstructedStylesheets()`? It would be nice to be clear that CEs using Custom Stylesheets will be automatically polyfilled, but it's a bit verbose.