### PR TITLE
Add tooltip custom element with position-anchor support on the `:host`

### DIFF
--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -72,8 +72,14 @@
             // properties, so no `style` attribute is produced and the polyfill
             // never sees them. Setting the literal attribute string preserves
             // the declarations for the polyfill to read.
-            this.setAttribute('style', 'position-anchor: --position-anchor-on-host');
-            target?.setAttribute('style', 'anchor-name: --position-anchor-on-host');
+            this.setAttribute(
+              'style',
+              'position-anchor: --position-anchor-on-host',
+            );
+            target?.setAttribute(
+              'style',
+              'anchor-name: --position-anchor-on-host',
+            );
 
             this.attachShadow({ mode: 'open' });
 
@@ -329,8 +335,8 @@ class AnchorAdoptedStyles extends HTMLElement {
         </p>
         <p>
           This demo uses <code>position-anchor</code> on a custom element host
-          (<code>&lt;position-anchor-on-host&gt;</code>), with <code>anchor()</code> in
-          the shadow root's <code>:host</code> styles.
+          (<code>&lt;position-anchor-on-host&gt;</code>), with
+          <code>anchor()</code> in the shadow root's <code>:host</code> styles.
         </p>
       </div>
 
@@ -376,7 +382,6 @@ class PositionAnchorOnHost extends HTMLElement {
 }
 customElements.define("position-anchor-on-host", PositionAnchorOnHost);
 &lt;/script&gt;
-</code></pre>
 </code></pre>
     </section>
     <section id="sponsor">

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -60,6 +60,52 @@
           }
         }
         customElements.define('anchor-adopted-styles', AnchorAdoptedStyles);
+
+        class Tooltip extends HTMLElement {
+          connectedCallback() {
+            const anchorName = `--x-tooltip-${Math.random().toString(36).slice(2)}`;
+            const targetId = this.getAttribute('for');
+            const target = targetId && this.getRootNode().getElementById(targetId);
+            // Write the anchor properties as raw `style` attribute strings.
+            // In browsers without native anchor-positioning support, the typed
+            // CSSOM (`el.style.anchorName = ...`) silently drops these unknown
+            // properties, so no `style` attribute is produced and the polyfill
+            // never sees them. Setting the literal attribute string preserves
+            // the declarations for the polyfill to read.
+            if (target) {
+              target.setAttribute(
+                'style',
+                `anchor-name: ${anchorName}; ${target.getAttribute('style') ?? ''}`,
+              );
+            }
+            this.setAttribute(
+              'style',
+              `position-anchor: ${anchorName}; ${this.getAttribute('style') ?? ''}`,
+            );
+
+            this.attachShadow({ mode: 'open' });
+
+            const sheet = new CSSStyleSheet();
+            sheet.replaceSync(`
+              :host {
+                position: absolute;
+                top: calc(anchor(top) - 4px);
+                left: anchor(center);
+                background: #222;
+                color: #fff;
+                padding: 4px 8px;
+                border-radius: 4px;
+                font-size: 0.8em;
+                white-space: nowrap;
+                pointer-events: none;
+                translate: -50% -100%;
+              }
+            `);
+            this.shadowRoot.adoptedStyleSheets = [sheet];
+            this.shadowRoot.innerHTML = '<slot></slot>';
+          }
+        }
+        customElements.define('x-tooltip', Tooltip);
       }
 
       const btn = document.getElementById('apply-polyfill');
@@ -78,7 +124,8 @@
           defineCustomElements();
 
           // Load the polyfill explicitly for the <anchor-web-component> demo.
-          // The <anchor-adopted-styles> is already covered by the adopted
+          // The <anchor-adopted-styles> and <x-tooltip> demos use
+          // `adoptedStyleSheets`, so they are already covered by the adopted
           // stylesheet patch.
           await polyfill({
             roots: [document.querySelector('anchor-web-component').shadowRoot],
@@ -266,6 +313,75 @@ class AnchorAdoptedStyles extends HTMLElement {
     `;
   }
 }
+&lt;/script&gt;
+</code></pre>
+    </section>
+    <section id="host-custom-element" class="demo-item">
+      <h2>
+        <a href="#host-custom-element" aria-hidden="true">🔗</a>
+        Works when a custom element host has <code>position-anchor</code>
+      </h2>
+      <div class="demo-elements">
+        <div style="position: relative; padding: 3em; text-align: center;">
+          <button id="button">Button</button>
+          <x-tooltip for="button">I am a tooltip</x-tooltip>
+        </div>
+      </div>
+      <div class="note">
+        <p>
+          With polyfill applied: The tooltip appears above the button,
+          centered horizontally.
+        </p>
+        <p>
+          This demo uses <code>position-anchor</code> on a custom element host
+          (<code>&lt;x-tooltip&gt;</code>), with <code>anchor()</code> in the
+          shadow root's <code>:host</code> styles.
+        </p>
+      </div>
+
+      <pre><code class="language-html"
+>&lt;button id="button"&gt;Button&lt;/button&gt;
+&lt;x-tooltip for="button"&gt;I am a tooltip&lt;/x-tooltip&gt;
+&lt;script&gt;
+class Tooltip extends HTMLElement {
+  connectedCallback() {
+    const anchorName = `--x-tooltip-${Math.random().toString(36).slice(2)}`;
+    const targetId = this.getAttribute("for");
+    const target = targetId &amp;&amp; this.getRootNode().getElementById(targetId);
+    if (target) {
+      target.setAttribute(
+        "style",
+        `anchor-name: ${anchorName}; ${target.getAttribute("style") ?? ""}`,
+      );
+    }
+    this.setAttribute(
+      "style",
+      `position-anchor: ${anchorName}; ${this.getAttribute("style") ?? ""}`,
+    );
+
+    this.attachShadow({ mode: "open" });
+
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(`
+      :host {
+        position: absolute;
+        top: calc(anchor(top) - 4px);
+        left: anchor(center);
+        background: #222;
+        color: #fff;
+        padding: 4px 8px;
+        border-radius: 4px;
+        font-size: 0.8em;
+        white-space: nowrap;
+        pointer-events: none;
+        translate: -50% -100%;
+      }
+    `);
+    this.shadowRoot.adoptedStyleSheets = [sheet];
+    this.shadowRoot.innerHTML = "&lt;slot&gt;&lt;/slot&gt;";
+  }
+}
+customElements.define("x-tooltip", Tooltip);
 &lt;/script&gt;
 </code></pre>
     </section>

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -63,24 +63,6 @@
 
         class PositionAnchorOnHost extends HTMLElement {
           connectedCallback() {
-            const targetId = this.getAttribute('for'),
-              target = targetId && this.getRootNode().getElementById(targetId);
-
-            // Write the anchor properties as raw `style` attribute strings.
-            // In browsers without native anchor-positioning support, the typed
-            // CSSOM (`el.style.anchorName = ...`) silently drops these unknown
-            // properties, so no `style` attribute is produced and the polyfill
-            // never sees them. Setting the literal attribute string preserves
-            // the declarations for the polyfill to read.
-            this.setAttribute(
-              'style',
-              'position-anchor: --position-anchor-on-host',
-            );
-            target?.setAttribute(
-              'style',
-              'anchor-name: --position-anchor-on-host',
-            );
-
             this.attachShadow({ mode: 'open' });
 
             const sheet = new CSSStyleSheet();
@@ -325,8 +307,8 @@ class AnchorAdoptedStyles extends HTMLElement {
         Works when a custom element host has <code>position-anchor</code>
       </h2>
       <div style="position: relative" class="demo-elements">
-        <div id="anchor" class="anchor">Anchor</div>
-        <position-anchor-on-host for="anchor">Target</position-anchor-on-host>
+        <div class="anchor" style="anchor-name: --position-anchor-on-host">Anchor</div>
+        <position-anchor-on-host style="position-anchor: --position-anchor-on-host">Target</position-anchor-on-host>
       </div>
       <div class="note">
         <p>
@@ -351,27 +333,13 @@ before any connectedCallback runs. --&gt;
 &lt;script&gt;
 class PositionAnchorOnHost extends HTMLElement {
   connectedCallback() {
-    const targetId = this.getAttribute("for"),
-      target = targetId &amp;&amp; this.getRootNode().getElementById(targetId);
-
-    this.setAttribute("style", "position-anchor: --position-anchor-on-host");
-    target?.setAttribute("style", "anchor-name: --position-anchor-on-host");
-
     this.attachShadow({ mode: "open" });
 
     const sheet = new CSSStyleSheet();
     sheet.replaceSync(`
       :host {
-        --element-color: var(--target, var(--outer-anchored));
-        background: var(--element-color);
-        border: thin solid var(--border);
-        border-radius: var(--radius-1);
-        color: white;
-        font-weight: bold;
         top: anchor(top);
         left: anchor(center);
-        padding: 0.5em;
-        white-space: nowrap;
         position: absolute;
         translate: -50% -100%;
       }

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -307,8 +307,13 @@ class AnchorAdoptedStyles extends HTMLElement {
         Works when a custom element host has <code>position-anchor</code>
       </h2>
       <div style="position: relative" class="demo-elements">
-        <div class="anchor" style="anchor-name: --position-anchor-on-host">Anchor</div>
-        <position-anchor-on-host style="position-anchor: --position-anchor-on-host">Target</position-anchor-on-host>
+        <div class="anchor" style="anchor-name: --position-anchor-on-host">
+          Anchor
+        </div>
+        <position-anchor-on-host
+          style="position-anchor: --position-anchor-on-host"
+          >Target</position-anchor-on-host
+        >
       </div>
       <div class="note">
         <p>

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -61,43 +61,36 @@
         }
         customElements.define('anchor-adopted-styles', AnchorAdoptedStyles);
 
-        class Tooltip extends HTMLElement {
+        class PositionAnchorOnHost extends HTMLElement {
           connectedCallback() {
-            const anchorName = `--x-tooltip-${Math.random().toString(36).slice(2)}`;
-            const targetId = this.getAttribute('for');
-            const target = targetId && this.getRootNode().getElementById(targetId);
+            const targetId = this.getAttribute('for'),
+              target = targetId && this.getRootNode().getElementById(targetId);
+
             // Write the anchor properties as raw `style` attribute strings.
             // In browsers without native anchor-positioning support, the typed
             // CSSOM (`el.style.anchorName = ...`) silently drops these unknown
             // properties, so no `style` attribute is produced and the polyfill
             // never sees them. Setting the literal attribute string preserves
             // the declarations for the polyfill to read.
-            if (target) {
-              target.setAttribute(
-                'style',
-                `anchor-name: ${anchorName}; ${target.getAttribute('style') ?? ''}`,
-              );
-            }
-            this.setAttribute(
-              'style',
-              `position-anchor: ${anchorName}; ${this.getAttribute('style') ?? ''}`,
-            );
+            this.setAttribute('style', 'position-anchor: --position-anchor-on-host');
+            target?.setAttribute('style', 'anchor-name: --position-anchor-on-host');
 
             this.attachShadow({ mode: 'open' });
 
             const sheet = new CSSStyleSheet();
             sheet.replaceSync(`
               :host {
-                position: absolute;
-                top: calc(anchor(top) - 4px);
+                --element-color: var(--target, var(--outer-anchored));
+                background: var(--element-color);
+                border: thin solid var(--border);
+                border-radius: var(--radius-1);
+                color: white;
+                font-weight: bold;
+                top: anchor(top);
                 left: anchor(center);
-                background: #222;
-                color: #fff;
-                padding: 4px 8px;
-                border-radius: 4px;
-                font-size: 0.8em;
+                padding: 0.5em;
                 white-space: nowrap;
-                pointer-events: none;
+                position: absolute;
                 translate: -50% -100%;
               }
             `);
@@ -105,7 +98,7 @@
             this.shadowRoot.innerHTML = '<slot></slot>';
           }
         }
-        customElements.define('x-tooltip', Tooltip);
+        customElements.define('position-anchor-on-host', PositionAnchorOnHost);
       }
 
       const btn = document.getElementById('apply-polyfill');
@@ -124,7 +117,7 @@
           defineCustomElements();
 
           // Load the polyfill explicitly for the <anchor-web-component> demo.
-          // The <anchor-adopted-styles> and <x-tooltip> demos use
+          // The <anchor-adopted-styles> and <position-anchor-on-host> demos use
           // `adoptedStyleSheets`, so they are already covered by the adopted
           // stylesheet patch.
           await polyfill({
@@ -321,59 +314,55 @@ class AnchorAdoptedStyles extends HTMLElement {
         <a href="#host-custom-element" aria-hidden="true">🔗</a>
         Works when a custom element host has <code>position-anchor</code>
       </h2>
-      <div class="demo-elements">
-        <div style="position: relative; padding: 3em; text-align: center;">
-          <button id="button">Button</button>
-          <x-tooltip for="button">I am a tooltip</x-tooltip>
-        </div>
+      <div style="position: relative" class="demo-elements">
+        <div id="anchor" class="anchor">Anchor</div>
+        <position-anchor-on-host for="anchor">Target</position-anchor-on-host>
       </div>
       <div class="note">
         <p>
-          With polyfill applied: The tooltip appears above the button,
-          centered horizontally.
+          With polyfill applied: Target is positioned above the Anchor,
+          horizontally centered on it.
         </p>
         <p>
           This demo uses <code>position-anchor</code> on a custom element host
-          (<code>&lt;x-tooltip&gt;</code>), with <code>anchor()</code> in the
-          shadow root's <code>:host</code> styles.
+          (<code>&lt;position-anchor-on-host&gt;</code>), with <code>anchor()</code> in
+          the shadow root's <code>:host</code> styles.
         </p>
       </div>
 
       <pre><code class="language-html"
->&lt;button id="button"&gt;Button&lt;/button&gt;
-&lt;x-tooltip for="button"&gt;I am a tooltip&lt;/x-tooltip&gt;
+>&lt;!-- Load the shadow entrypoint before defining custom elements,
+so the replaceSync and adoptedStyleSheets patches are installed
+before any connectedCallback runs. --&gt;
+&lt;script type="module" src="/dist/css-anchor-positioning-shadow.js"&gt;&lt;/script&gt;
+
+&lt;div id="anchor" class="anchor"&gt;Anchor&lt;/div&gt;
+&lt;position-anchor-on-host for="anchor"&gt;Target&lt;/position-anchor-on-host&gt;
 &lt;script&gt;
-class Tooltip extends HTMLElement {
+class PositionAnchorOnHost extends HTMLElement {
   connectedCallback() {
-    const anchorName = `--x-tooltip-${Math.random().toString(36).slice(2)}`;
-    const targetId = this.getAttribute("for");
-    const target = targetId &amp;&amp; this.getRootNode().getElementById(targetId);
-    if (target) {
-      target.setAttribute(
-        "style",
-        `anchor-name: ${anchorName}; ${target.getAttribute("style") ?? ""}`,
-      );
-    }
-    this.setAttribute(
-      "style",
-      `position-anchor: ${anchorName}; ${this.getAttribute("style") ?? ""}`,
-    );
+    const targetId = this.getAttribute("for"),
+      target = targetId &amp;&amp; this.getRootNode().getElementById(targetId);
+
+    this.setAttribute("style", "position-anchor: --position-anchor-on-host");
+    target?.setAttribute("style", "anchor-name: --position-anchor-on-host");
 
     this.attachShadow({ mode: "open" });
 
     const sheet = new CSSStyleSheet();
     sheet.replaceSync(`
       :host {
-        position: absolute;
-        top: calc(anchor(top) - 4px);
+        --element-color: var(--target, var(--outer-anchored));
+        background: var(--element-color);
+        border: thin solid var(--border);
+        border-radius: var(--radius-1);
+        color: white;
+        font-weight: bold;
+        top: anchor(top);
         left: anchor(center);
-        background: #222;
-        color: #fff;
-        padding: 4px 8px;
-        border-radius: 4px;
-        font-size: 0.8em;
+        padding: 0.5em;
         white-space: nowrap;
-        pointer-events: none;
+        position: absolute;
         translate: -50% -100%;
       }
     `);
@@ -381,8 +370,9 @@ class Tooltip extends HTMLElement {
     this.shadowRoot.innerHTML = "&lt;slot&gt;&lt;/slot&gt;";
   }
 }
-customElements.define("x-tooltip", Tooltip);
+customElements.define("position-anchor-on-host", PositionAnchorOnHost);
 &lt;/script&gt;
+</code></pre>
 </code></pre>
     </section>
     <section id="sponsor">

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -272,7 +272,7 @@ function hostMatchesSelector(host: HTMLElement, selector: string): boolean {
   const match = /^:host\(\s*(.+?)\s*\)$/.exec(trimmed);
   if (match) {
     try {
-      return host.matches(match[1]);
+      return match[1].split(',').some(m => host.matches(m.trim()));
     } catch {
       return false;
     }

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -258,11 +258,42 @@ export const getOffsetParent = async (el: HTMLElement) => {
   return offsetParent as HTMLElement;
 };
 
+/**
+ * Checks whether a shadow root's host element matches a `:host` or
+ * `:host(<compound-selector>)` selector. The `:host` pseudo-class cannot be
+ * matched via `querySelectorAll()` from within the shadow root, so we resolve
+ * it manually against the host element.
+ */
+function hostMatchesSelector(host: HTMLElement, selector: string): boolean {
+  const trimmed = selector.trim();
+  if (trimmed === ':host') {
+    return true;
+  }
+  const match = /^:host\(\s*(.+?)\s*\)$/.exec(trimmed);
+  if (match) {
+    try {
+      return host.matches(match[1]);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 export const querySelectorAllRoots = (
   roots: AnchorPositioningRoot[],
   selector: string,
 ): HTMLElement[] => {
-  return roots.flatMap(
-    (e) => [...e.querySelectorAll(selector)] as HTMLElement[],
-  );
+  return roots.flatMap((root) => {
+    const elements = [...root.querySelectorAll(selector)] as HTMLElement[];
+    // `:host` (and `:host(...)`) selectors don't match via `querySelectorAll()`
+    // within a shadow root, so resolve them to the shadow root's host element.
+    if (root instanceof ShadowRoot) {
+      const host = root.host as HTMLElement;
+      if (hostMatchesSelector(host, selector)) {
+        elements.push(host);
+      }
+    }
+    return elements;
+  });
 };

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -300,3 +300,29 @@ export const querySelectorAllRoots = (
     return elements;
   });
 };
+
+/** A selector paired with the tree (root) it was authored in. */
+export interface ScopedSelector {
+  selector: string;
+  root: AnchorPositioningRoot;
+}
+
+/**
+ * Resolves selectors to elements, querying each selector only within the tree
+ * (root) it was authored in, per the CSS tree-scoping rules. Selectors that
+ * share a root are combined into a single query so duplicate matches collapse
+ * (matching `querySelectorAll`'s behavior for a comma-separated selector list).
+ */
+export const querySelectorAllScoped = (
+  selectors: ScopedSelector[],
+): HTMLElement[] => {
+  const selectorsByRoot = new Map<AnchorPositioningRoot, Set<string>>();
+  for (const { selector, root } of selectors) {
+    const set = selectorsByRoot.get(root) ?? new Set<string>();
+    set.add(selector);
+    selectorsByRoot.set(root, set);
+  }
+  return [...selectorsByRoot].flatMap(([root, set]) =>
+    querySelectorAllRoots([root], [...set].join(',')),
+  );
+};

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -12,6 +12,9 @@ export interface Selector {
   selector: string;
   elementPart: string;
   pseudoElementPart?: string;
+  // The tree (document or shadow root) this selector was authored in, so anchor
+  // resolution can be scoped to the same tree per the CSS scoping rules.
+  root: AnchorPositioningRoot;
 }
 
 /**

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -272,7 +272,7 @@ function hostMatchesSelector(host: HTMLElement, selector: string): boolean {
   const match = /^:host\(\s*(.+?)\s*\)$/.exec(trimmed);
   if (match) {
     try {
-      return match[1].split(',').some(m => host.matches(m.trim()));
+      return match[1].split(',').some((m) => host.matches(m.trim()));
     } catch {
       return false;
     }

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -13,7 +13,7 @@ import { clone, List } from 'css-tree/utils';
 import walk from 'css-tree/walker';
 import { nanoid } from 'nanoid/non-secure';
 
-import { getCSSPropertyValue } from './dom.js';
+import { getCSSPropertyValue, type ScopedSelector } from './dom.js';
 import {
   type AnchorPosition,
   type AnchorPositions,
@@ -50,8 +50,9 @@ interface AtRuleRaw extends Atrule {
 }
 
 // `key` is the `@position-try` block uuid
-// `value` is the target element selector
-type FallbackTargets = Record<string, string[]>;
+// `value` is the target element selectors, each paired with the tree (root) it
+// was authored in, so target resolution can be scoped to that tree.
+type FallbackTargets = Record<string, ScopedSelector[]>;
 
 type Fallbacks = Record<
   // `key` is a reference to a specific `position-try-fallbacks` value, which
@@ -580,7 +581,7 @@ export function parsePositionFallbacks(styleData: StyleData[]) {
         if (order) {
           anchorPosition.order = order;
         }
-        selectors.forEach(({ selector }) => {
+        selectors.forEach(({ selector, root }) => {
           options?.forEach((tryObject) => {
             let name;
             // Apply try fallback
@@ -619,9 +620,9 @@ export function parsePositionFallbacks(styleData: StyleData[]) {
 
             if (name && fallbacks[name]) {
               const dataAttr = `[data-anchor-polyfill="${fallbacks[name].uuid}"]`;
-              // Store mapping of data-attr to target selectors
+              // Store mapping of data-attr to target selectors (with their root)
               fallbackTargets[dataAttr] ??= [];
-              fallbackTargets[dataAttr].push(selector);
+              fallbackTargets[dataAttr].push({ selector, root });
 
               if (!fallbacksAdded.has(name)) {
                 anchorPosition.fallbacks ??= [];

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -570,7 +570,7 @@ export function parsePositionFallbacks(styleData: StyleData[]) {
       visit: 'Declaration',
       enter(node) {
         const rule = this.rule?.prelude as SelectorList | undefined;
-        const selectors = getSelectors(rule);
+        const selectors = getSelectors(rule, styleObj.root);
         if (!selectors.length) return;
 
         // Parse `position-try`, `position-try-order`, and

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -94,7 +94,11 @@ function fetchInlineStyles(elements?: HTMLElement[]) {
       el.setAttribute(dataAttribute, selector);
       const styles = el.getAttribute('style');
       const css = `[${dataAttribute}="${selector}"] { ${styles} }`;
-      inlineStyles.push({ el, css });
+      inlineStyles.push({
+        el,
+        css,
+        root: el.getRootNode() as AnchorPositioningRoot,
+      });
     });
 
   return inlineStyles;
@@ -117,9 +121,14 @@ function fetchAdoptedStyleSheets(roots: AnchorPositioningRoot[]) {
         continue;
       }
       seen.add(sheet);
+      // TODO(tree-scope): a constructed stylesheet can be adopted on multiple
+      // roots. We currently attribute it to the first adopting root. Fully
+      // tree-scoping shared sheets means emitting one StyleData per (sheet,
+      // root) and reconciling the write-back in `transformCSS`.
       adoptedStyles.push({
         css: getAdoptedStylesheetText(sheet),
         sheet,
+        root,
       });
     }
   }
@@ -136,14 +145,15 @@ export async function fetchCSS(
   targetElements
     .filter((el) => el instanceof HTMLElement)
     .forEach((el) => {
+      const root = el.getRootNode() as AnchorPositioningRoot;
       if (el.tagName.toLowerCase() === 'link') {
         const url = getStylesheetUrl(el as HTMLLinkElement);
         if (url) {
-          sources.push({ el, url });
+          sources.push({ el, url, root });
         }
       }
       if (el.tagName.toLowerCase() === 'style') {
-        sources.push({ el, css: el.innerHTML });
+        sources.push({ el, css: el.innerHTML, root });
       }
     });
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -347,7 +347,7 @@ export async function parseCSS(
     const ast = getAST(styleObj.css);
     walk(ast, function (node) {
       const rule = this.rule?.prelude as SelectorList | undefined;
-      const selectors = getSelectors(rule);
+      const selectors = getSelectors(rule, styleObj.root);
 
       // Parse `anchor-name` declaration
       if (isAnchorNameDeclaration(node) && selectors.length) {
@@ -630,7 +630,7 @@ export async function parseCSS(
           // properties, the value will be different each time. So we append
           // the property to the uuid, and update the CSS property to point
           // to the new uuid...
-          const selectors = getSelectors(rule);
+          const selectors = getSelectors(rule, styleObj.root);
 
           for (const anchorFnData of [...anchorFns, ...referencedFns]) {
             const data = { ...anchorFnData };
@@ -791,6 +791,7 @@ export async function parseCSS(
     changed: false,
     created: true,
     css: '',
+    root: document,
   };
   styleData.push(positionAreaMappingStyleElement);
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -263,6 +263,18 @@ function getAnchorFunctionData(node: CssNode, declaration: Declaration | null) {
   return {};
 }
 
+/**
+ * Whether the element declares `position-anchor` in its own inline `style`
+ * attribute. This is used to distinguish a `position-anchor` that is tree-scoped
+ * to the element's own tree (e.g. an inline style on a shadow host, in the light
+ * DOM) from one inherited via a shadow-scoped `:host` rule. Only the former may
+ * reference an anchor in the host's outer tree.
+ */
+function hasInlinePositionAnchor(el: HTMLElement): boolean {
+  const style = el.getAttribute('style');
+  return style ? /(?:^|;)\s*position-anchor\s*:/i.test(style) : false;
+}
+
 async function getAnchorEl(
   targetEl: HTMLElement | null,
   anchorObj: AnchorFunction | null,
@@ -270,6 +282,10 @@ async function getAnchorEl(
 ) {
   let anchorName = anchorObj?.anchorName;
   const customPropName = anchorObj?.customPropName;
+  // Whether `anchorName` was resolved from a `position-anchor` declaration in
+  // the target's own tree (e.g. an inline style on a shadow host), as opposed
+  // to an explicit `anchor()` name or a shadow-scoped `:host` rule.
+  let anchorNameFromOwnTree = false;
   if (targetEl && !anchorName) {
     const positionAnchorProperty = getCSSPropertyValue(
       targetEl,
@@ -278,6 +294,7 @@ async function getAnchorEl(
 
     if (positionAnchorProperty) {
       anchorName = positionAnchorProperty;
+      anchorNameFromOwnTree = hasInlinePositionAnchor(targetEl);
     } else if (customPropName) {
       anchorName = getCSSPropertyValue(targetEl, customPropName);
     }
@@ -289,12 +306,17 @@ async function getAnchorEl(
   const anchorNameScopeSelectors = anchorName
     ? anchorScopes[anchorName] || []
     : [];
-  // When the target is a shadow host (e.g. matched via a `:host` rule), its
-  // anchor can live in the host's own tree (the light DOM), outside the roots
-  // being polyfilled. Include the target's root node so such anchors are found.
+  // When the target is a shadow host with `position-anchor` set in its own tree
+  // (e.g. an inline style), its anchor lives in the host's own tree (the light
+  // DOM), outside the roots being polyfilled. Include the target's root node so
+  // such anchors are found. Anchor names that are tree-scoped to the shadow tree
+  // — an explicit `anchor()` name or `position-anchor` from a `:host` rule —
+  // must NOT resolve to anchors in the outer tree, so the search is not extended
+  // for them.
   let roots = options.roots;
   const targetRoot = targetEl?.getRootNode();
   if (
+    anchorNameFromOwnTree &&
     (targetRoot instanceof Document || targetRoot instanceof ShadowRoot) &&
     !roots.includes(targetRoot)
   ) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -14,7 +14,7 @@ import {
   AnchorScopeValue,
   getCSSPropertyValue,
   type PseudoElement,
-  querySelectorAllRoots,
+  querySelectorAllScoped,
   type Selector,
 } from './dom.js';
 import { parsePositionFallbacks, type PositionTryOrder } from './fallback.js';
@@ -337,6 +337,13 @@ export async function parseCSS(
 ) {
   const anchorFunctions: AnchorFunctionDeclarations = {};
   const positionAreas: PositionAreaDeclarations = {};
+  // For each target selector used as a key in `anchorFunctions`/`positionAreas`,
+  // remember the selectors (with their authoring root) so the targets can be
+  // resolved within the tree they were authored in, rather than across all roots.
+  const targetSelectors: Record<string, Selector[]> = {};
+  const recordTarget = (sel: Selector) => {
+    (targetSelectors[sel.selector] ??= []).push(sel);
+  };
   resetStores();
 
   // Parse `position-try` and related declarations/rules
@@ -377,11 +384,13 @@ export async function parseCSS(
         // *and* the same exact declaration property:
         // (e.g. multiple `top: anchor(...)` declarations
         // for the same `.foo {...}` selector)
-        for (const { selector } of selectors) {
+        for (const sel of selectors) {
+          const { selector } = sel;
           anchorFunctions[selector] = {
             ...anchorFunctions[selector],
             [prop]: [...(anchorFunctions[selector]?.[prop] ?? []), data],
           };
+          recordTarget(sel);
         }
       }
 
@@ -393,11 +402,13 @@ export async function parseCSS(
             positionAreaDeclaration,
             this.block,
           );
-          for (const { selector } of selectors) {
+          for (const sel of selectors) {
+            const { selector } = sel;
             positionAreas[selector] = [
               ...(positionAreas[selector] ?? []),
               positionAreaDeclaration,
             ];
+            recordTarget(sel);
           }
         }
       }
@@ -638,11 +649,13 @@ export async function parseCSS(
             const uuid = data.uuid;
             data.uuid = uuidWithProp;
 
-            for (const { selector } of selectors) {
+            for (const sel of selectors) {
+              const { selector } = sel;
               anchorFunctions[selector] = {
                 ...anchorFunctions[selector],
                 [prop]: [...(anchorFunctions[selector]?.[prop] ?? []), data],
               };
+              recordTarget(sel);
             }
             // Store new name with declaration prop appended,
             // so that we can go back and update the original custom
@@ -736,12 +749,9 @@ export async function parseCSS(
     ) {
       // If we're dealing with a `@position-try` block,
       // then the targets are places where that `position-fallback` is used.
-      targets = querySelectorAllRoots(
-        options.roots,
-        fallbackTargets[targetSel].join(','),
-      );
+      targets = querySelectorAllScoped(fallbackTargets[targetSel]);
     } else {
-      targets = querySelectorAllRoots(options.roots, targetSel);
+      targets = querySelectorAllScoped(targetSelectors[targetSel] ?? []);
     }
     for (const [targetProperty, anchorObjects] of Object.entries(anchorFns) as [
       InsetProperty | SizingProperty,
@@ -803,7 +813,7 @@ export async function parseCSS(
   // .foo { position-area: end }
 
   for (const [targetSel, positions] of Object.entries(positionAreas)) {
-    const targets = querySelectorAllRoots(options.roots, targetSel);
+    const targets = querySelectorAllScoped(targetSelectors[targetSel] ?? []);
     for (const targetEl of targets) {
       // For every target element, find a valid anchor element.
       const anchorEl = await getAnchorEl(targetEl, null, {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -289,12 +289,23 @@ async function getAnchorEl(
   const anchorNameScopeSelectors = anchorName
     ? anchorScopes[anchorName] || []
     : [];
+  // When the target is a shadow host (e.g. matched via a `:host` rule), its
+  // anchor can live in the host's own tree (the light DOM), outside the roots
+  // being polyfilled. Include the target's root node so such anchors are found.
+  let roots = options.roots;
+  const targetRoot = targetEl?.getRootNode();
+  if (
+    (targetRoot instanceof Document || targetRoot instanceof ShadowRoot) &&
+    !roots.includes(targetRoot)
+  ) {
+    roots = [...roots, targetRoot];
+  }
   return await validatedForPositioning(
     targetEl,
     anchorName || null,
     anchorSelectors,
     [...allScopeSelectors, ...anchorNameScopeSelectors],
-    { roots: options.roots },
+    { roots },
   );
 }
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -27,8 +27,8 @@ export function transformCSS(
   cleanup = false,
 ) {
   const updatedStyleData: StyleData[] = [];
-  for (const { el, css, changed, created = false, sheet } of styleData) {
-    const updatedObject: StyleData = { el, css, changed: false, sheet };
+  for (const { el, css, changed, created = false, sheet, root } of styleData) {
+    const updatedObject: StyleData = { el, css, changed: false, sheet, root };
     if (changed) {
       if (sheet) {
         // Handle constructed stylesheets adopted via `adoptedStyleSheets`.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,7 @@ import { clone } from 'css-tree/utils';
 import { nanoid } from 'nanoid/non-secure';
 
 import type { Selector } from './dom.js';
+import type { AnchorPositioningRoot } from './polyfill.js';
 
 export const INSTANCE_UUID = nanoid();
 
@@ -65,6 +66,10 @@ export function getDeclarationValue(node: DeclarationWithValue) {
 export interface StyleData {
   el?: HTMLElement;
   css: string;
+  // The tree (document or shadow root) this stylesheet was authored in. Used to
+  // tree-scope `anchor-name` / `anchor()` / `position-anchor` resolution per the
+  // CSS scoping rules, rather than treating all roots as one flat namespace.
+  root: AnchorPositioningRoot;
   url?: URL;
   changed?: boolean;
   created?: boolean; // Whether the element is created by the polyfill
@@ -141,7 +146,10 @@ export function splitCommaList(list: List<CssNode>) {
   );
 }
 
-export function getSelectors(rule: SelectorList | undefined) {
+export function getSelectors(
+  rule: SelectorList | undefined,
+  root: AnchorPositioningRoot,
+) {
   if (!rule) return [];
 
   return (rule.children as List<CssTreeSelector>)
@@ -160,6 +168,7 @@ export function getSelectors(rule: SelectorList | undefined) {
         selector: elementPart + (pseudoElementPart ?? ''),
         elementPart,
         pseudoElementPart,
+        root,
       } satisfies Selector;
     })
     .toArray();

--- a/tests/e2e/shadow-dom.test.ts
+++ b/tests/e2e/shadow-dom.test.ts
@@ -85,7 +85,7 @@ test('applies polyfill for adopted stylesheets in shadow root', async ({
 test('positions a custom element host anchored via position-anchor', async ({
   page,
 }) => {
-  const buttonSelector = '#host-custom-element #anchor';
+  const buttonSelector = '#host-custom-element .anchor';
   const tooltipSelector = '#host-custom-element position-anchor-on-host';
   const button = page.locator(buttonSelector);
   const tooltip = page.locator(tooltipSelector);

--- a/tests/e2e/shadow-dom.test.ts
+++ b/tests/e2e/shadow-dom.test.ts
@@ -85,8 +85,8 @@ test('applies polyfill for adopted stylesheets in shadow root', async ({
 test('positions a custom element host anchored via position-anchor', async ({
   page,
 }) => {
-  const buttonSelector = '#host-custom-element #button';
-  const tooltipSelector = '#host-custom-element x-tooltip';
+  const buttonSelector = '#host-custom-element #anchor';
+  const tooltipSelector = '#host-custom-element position-anchor-on-host';
   const button = page.locator(buttonSelector);
   const tooltip = page.locator(tooltipSelector);
 
@@ -100,11 +100,11 @@ test('positions a custom element host anchored via position-anchor', async ({
   const buttonRect = await getRect(button);
   const tooltipRect = await getRect(tooltip);
 
-  // The tooltip's `:host` rule uses `top: calc(anchor(top) - 4px)`,
-  // `left: anchor(center)` and `translate: -50% -100%`, so it should sit 4px
-  // above the button, horizontally centered on it.
+  // The target's `:host` rule uses `top: anchor(top)`, `left: anchor(center)`
+  // and `translate: -50% -100%`, so it should sit above the anchor,
+  // horizontally centered on it.
   const buttonCenterX = buttonRect.left + buttonRect.width / 2;
   const tooltipCenterX = tooltipRect.left + tooltipRect.width / 2;
   expect(tooltipCenterX).toBeCloseTo(buttonCenterX, 0);
-  expect(tooltipRect.bottom).toBeCloseTo(buttonRect.top - 4, 0);
+  expect(tooltipRect.bottom).toBeCloseTo(buttonRect.top, 0);
 });

--- a/tests/e2e/shadow-dom.test.ts
+++ b/tests/e2e/shadow-dom.test.ts
@@ -81,3 +81,30 @@ test('applies polyfill for adopted stylesheets in shadow root', async ({
   await expectWithinOne(target, 'top', parentHeight);
   await expectWithinOne(target, 'right', expected);
 });
+
+test('positions a custom element host anchored via position-anchor', async ({
+  page,
+}) => {
+  const buttonSelector = '#host-custom-element #button';
+  const tooltipSelector = '#host-custom-element x-tooltip';
+  const button = page.locator(buttonSelector);
+  const tooltip = page.locator(tooltipSelector);
+
+  const getRect = (locator: typeof button) =>
+    locator.evaluate((node: HTMLElement) =>
+      node.getBoundingClientRect().toJSON(),
+    );
+
+  await applyPolyfill(page);
+
+  const buttonRect = await getRect(button);
+  const tooltipRect = await getRect(tooltip);
+
+  // The tooltip's `:host` rule uses `top: calc(anchor(top) - 4px)`,
+  // `left: anchor(center)` and `translate: -50% -100%`, so it should sit 4px
+  // above the button, horizontally centered on it.
+  const buttonCenterX = buttonRect.left + buttonRect.width / 2;
+  const tooltipCenterX = tooltipRect.left + tooltipRect.width / 2;
+  expect(tooltipCenterX).toBeCloseTo(buttonCenterX, 0);
+  expect(tooltipRect.bottom).toBeCloseTo(buttonRect.top - 4, 0);
+});

--- a/tests/e2e/validate.test.ts
+++ b/tests/e2e/validate.test.ts
@@ -46,10 +46,14 @@ test.afterAll(async ({ browser }) => {
   await browser.close();
 });
 
+// A bare selector shape passed across the Playwright serialization boundary.
+// `Selector.root` is omitted here (it is unused by `validatedForPositioning`):
+// its `Document | HTMLElement | ShadowRoot` type is not serializable and makes
+// `page.evaluate`'s arg types recurse, so callers cast to `Selector` in-page.
 const anchorSelector = {
   selector: '#my-anchor-positioning',
   elementPart: '#my-anchor-positioning',
-} satisfies Selector;
+};
 const targetSelector = '#my-target-positioning';
 
 async function callValidFunction(page: Page) {
@@ -419,7 +423,7 @@ test('when multiple anchor elements have the same name and are valid, the last i
       const anchor = await validatedForPositioning(
         targetElement,
         /* anchorName: */ null,
-        [anchorSelector],
+        [anchorSelector as unknown as Selector],
         /* scopeSelectors: */ [],
         { roots: [document] },
       ).then((value) => value);
@@ -514,7 +518,7 @@ test('target anchor element is first element el in tree order.', async ({
       const anchor = await validatedForPositioning(
         targetElement,
         /* anchorName: */ null,
-        [anchorSelector],
+        [anchorSelector as unknown as Selector],
         /* scopeSelectors: */ [],
         { roots: [document] },
       ).then((value) => value);
@@ -529,10 +533,7 @@ test('target anchor element is first element el in tree order.', async ({
 
       return validatedData;
     },
-    [
-      { selector: '.anchor1', elementPart: '.anchor1' } satisfies Selector,
-      '.target9',
-    ] as const,
+    [{ selector: '.anchor1', elementPart: '.anchor1' }, '.target9'] as const,
   );
 
   await page.close();

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -21,7 +21,7 @@ export const sampleBaseCSS = '.a { color: red; } .b { color: green; }';
  * Update a CSS string used in tests by running it through `cascadeCSS`.
  */
 export function cascadeCSSForTest(css: string) {
-  const styleObj: StyleData = { el: null!, css };
+  const styleObj: StyleData = { el: null!, css, root: document };
   cascadeCSS([styleObj]);
   return styleObj.css;
 }

--- a/tests/unit/cascade.test.ts
+++ b/tests/unit/cascade.test.ts
@@ -16,7 +16,7 @@ describe('cascadeCSS', () => {
   it('adds insets with anchors as custom properties', async () => {
     const srcCSS = getSampleCSS('position-try-tactics');
     const styleData: StyleData[] = [
-      { css: srcCSS, el: document.createElement('div') },
+      { css: srcCSS, el: document.createElement('div'), root: document },
     ];
     const cascadeCausedChanges = await cascadeCSS(styleData);
     expect(cascadeCausedChanges).toBe(true);
@@ -27,7 +27,7 @@ describe('cascadeCSS', () => {
   it('returns false if no changes were made', async () => {
     const srcCSS = `.my-class { color: blue; }`;
     const styleData: StyleData[] = [
-      { css: srcCSS, el: document.createElement('div') },
+      { css: srcCSS, el: document.createElement('div'), root: document },
     ];
     const cascadeCausedChanges = await cascadeCSS(styleData);
     expect(cascadeCausedChanges).toBe(false);

--- a/tests/unit/dom.test.ts
+++ b/tests/unit/dom.test.ts
@@ -1,0 +1,67 @@
+import { querySelectorAllScoped } from '../../src/dom.js';
+
+describe('querySelectorAllScoped', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('scopes each selector to the tree (root) it was authored in', () => {
+    document.body.innerHTML = `
+      <div class="target" id="light-target"></div>
+      <div id="host"></div>
+    `;
+    const lightTarget = document.getElementById('light-target')!;
+    const host = document.getElementById('host')!;
+    const shadow = host.attachShadow({ mode: 'open' });
+    shadow.innerHTML = '<div class="target" id="shadow-target"></div>';
+    const shadowTarget = shadow.getElementById('shadow-target')!;
+
+    // A selector authored in the document only resolves within the document.
+    expect(
+      querySelectorAllScoped([{ selector: '.target', root: document }]),
+    ).toEqual([lightTarget]);
+
+    // The same selector authored in the shadow root only resolves there.
+    expect(
+      querySelectorAllScoped([{ selector: '.target', root: shadow }]),
+    ).toEqual([shadowTarget]);
+
+    // Selectors from different roots each resolve within their own tree.
+    expect(
+      querySelectorAllScoped([
+        { selector: '.target', root: document },
+        { selector: '.target', root: shadow },
+      ]),
+    ).toEqual([lightTarget, shadowTarget]);
+  });
+
+  it('resolves `:host` against the shadow root host element', () => {
+    document.body.innerHTML = '<div id="host" class="card"></div>';
+    const host = document.getElementById('host')!;
+    const shadow = host.attachShadow({ mode: 'open' });
+
+    expect(
+      querySelectorAllScoped([{ selector: ':host', root: shadow }]),
+    ).toEqual([host]);
+    expect(
+      querySelectorAllScoped([{ selector: ':host(.card)', root: shadow }]),
+    ).toEqual([host]);
+    expect(
+      querySelectorAllScoped([{ selector: ':host(.other)', root: shadow }]),
+    ).toEqual([]);
+  });
+
+  it('collapses duplicate matches for selectors sharing a root', () => {
+    document.body.innerHTML = '<div class="a b" id="el"></div>';
+    const el = document.getElementById('el')!;
+
+    // `.a` and `.a.b` both match the same element; like a comma-separated
+    // `querySelectorAll`, the element is only returned once.
+    expect(
+      querySelectorAllScoped([
+        { selector: '.a', root: document },
+        { selector: '.a.b', root: document },
+      ]),
+    ).toEqual([el]);
+  });
+});

--- a/tests/unit/parse.test.ts
+++ b/tests/unit/parse.test.ts
@@ -13,9 +13,12 @@ describe('parseCSS', () => {
   });
 
   it('handles css with no `anchor()` fn', async () => {
-    const { rules } = await parseCSS([{ css: sampleBaseCSS }] as StyleData[], {
-      roots: [document],
-    });
+    const { rules } = await parseCSS(
+      [{ css: sampleBaseCSS, root: document }] as StyleData[],
+      {
+        roots: [document],
+      },
+    );
 
     expect(rules).toEqual({});
   });
@@ -31,7 +34,7 @@ describe('parseCSS', () => {
     const targetEl = document.getElementById('my-target-positioning');
     const css = getSampleCSS('anchor-positioning');
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
 
@@ -71,7 +74,7 @@ describe('parseCSS', () => {
       '<div id="my-anchor-name-prop"></div></div>';
     const css = getSampleCSS('anchor-name-custom-prop');
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -113,7 +116,7 @@ describe('parseCSS', () => {
       }
     `;
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -159,7 +162,7 @@ describe('parseCSS', () => {
       }
     `);
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -218,7 +221,7 @@ describe('parseCSS', () => {
       }
     `);
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -271,7 +274,7 @@ describe('parseCSS', () => {
       }
     `);
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -299,7 +302,7 @@ describe('parseCSS', () => {
       '<div style="position: relative"><div id="my-target"></div><div id="my-anchor"></div></div>';
     const css = getSampleCSS('anchor');
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -337,7 +340,7 @@ describe('parseCSS', () => {
       '<div style="position: relative"><div id="my-target-props"></div><div id="my-anchor-props"></div></div>';
     const css = getSampleCSS('anchor-custom-props');
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -375,7 +378,7 @@ describe('parseCSS', () => {
       '<div style="position: relative"><div id="target-duplicate-custom-props"></div><div id="anchor-duplicate-custom-props"></div></div>';
     const css = getSampleCSS('anchor-duplicate-custom-props');
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -445,7 +448,7 @@ describe('parseCSS', () => {
       '<div style="position: relative"><div id="my-anchor-name-list"></div><div id="my-target-name-list-a"></div><div id="my-target-name-list-b"></div></div>';
     const css = getSampleCSS('anchor-name-list');
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -507,7 +510,7 @@ describe('parseCSS', () => {
       '<div style="position: relative"><div id="my-target-math"></div><div id="my-anchor-math"></div></div>';
     const css = getSampleCSS('anchor-math');
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -566,7 +569,7 @@ describe('parseCSS', () => {
       }
     `);
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -623,7 +626,7 @@ describe('parseCSS', () => {
     const anchorEl = document.getElementById('my-anchor-size');
     const css = getSampleCSS('anchor-size');
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
 
@@ -659,7 +662,7 @@ describe('parseCSS', () => {
     `;
     const css = getSampleCSS('position-try');
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const anchorEl = document.getElementById('my-anchor-fallback');
@@ -794,7 +797,7 @@ describe('parseCSS', () => {
         position-fallback: --fallback;
       }
     `;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
 
@@ -819,7 +822,7 @@ describe('parseCSS', () => {
       }
     `);
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const li = document.querySelectorAll('li');
@@ -870,7 +873,7 @@ describe('parseCSS', () => {
       }
     `);
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -914,7 +917,7 @@ describe('parseCSS', () => {
       }
     `);
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -957,7 +960,7 @@ describe('parseCSS', () => {
       }
     `);
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -999,7 +1002,7 @@ describe('parseCSS', () => {
       }
     `);
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {
@@ -1040,7 +1043,7 @@ describe('parseCSS', () => {
       }
     `);
     document.head.innerHTML = `<style>${css}</style>`;
-    const { rules } = await parseCSS([{ css }] as StyleData[], {
+    const { rules } = await parseCSS([{ css, root: document }] as StyleData[], {
       roots: [document],
     });
     const expected = {

--- a/tests/unit/transform.test.ts
+++ b/tests/unit/transform.test.ts
@@ -17,17 +17,19 @@ describe('transformCSS', () => {
     const div = document.getElementById('div') as HTMLDivElement;
     const div2 = document.getElementById('div2') as HTMLDivElement;
     const styleData = [
-      { el: link, css: 'html { margin: 0; }', changed: true },
-      { el: style, css: 'html { padding: 0; }', changed: true },
+      { el: link, css: 'html { margin: 0; }', changed: true, root: document },
+      { el: style, css: 'html { padding: 0; }', changed: true, root: document },
       {
         el: div,
         css: '[data-has-inline-styles="key"]{color:blue;}',
         changed: true,
+        root: document,
       },
       {
         el: div2,
         css: '[data-has-inline-styles="key2"]{color:blue;}',
         changed: false,
+        root: document,
       },
     ];
     const inlineStyles = new Map();
@@ -54,7 +56,9 @@ describe('transformCSS', () => {
       <link id="the-link" media="screen" title="stylish" rel="stylesheet" href="/sample.css"/>
     `;
     const link = document.querySelector('link') as HTMLLinkElement;
-    const styleData = [{ el: link, css: 'html { margin: 0; }', changed: true }];
+    const styleData = [
+      { el: link, css: 'html { margin: 0; }', changed: true, root: document },
+    ];
     const inlineStyles = new Map();
     const initialStyleElement = document.querySelector('style');
     expect(initialStyleElement).toBe(null);
@@ -78,6 +82,7 @@ describe('transformCSS', () => {
         css: 'html { margin: 0; }',
         changed: true,
         created: true,
+        root: document,
       },
     ];
     transformCSS(styleData, undefined, true);


### PR DESCRIPTION
Fixes #408

## What this fixes

When `position-anchor` is set on a **custom element host** (i.e. via a `:host` rule in an adopted stylesheet), the polyfill failed to position the element. Three separate issues combined to cause this:

1. **`:host` targets were never matched.** `querySelectorAll(':host')` returns nothing when called from within a shadow root, so the polyfill never recognised the custom element as a target. Fixed in `src/dom.ts` by resolving `:host`/`:host(...)` selectors directly against the shadow root's host element.

2. **The anchor lived outside the polyfilled roots.** The anchor element (e.g. a `<div>` in the light DOM) was not in any of the shadow roots passed to `polyfill()`, so `getAnchorEl` couldn't find it. Fixed in `src/parse.ts` by also searching the target element's own root node when looking up its anchor.

3. **Inline styles set via typed CSSOM were silently dropped.** Setting `el.style.anchorName = ...` in a browser without native anchor-positioning support discards the unknown declaration, leaving no `style` attribute for the polyfill to read. Fixed in the demo (`shadow-dom.html`) by writing the declarations as raw attribute strings via `setAttribute('style', ...)`, which browsers preserve literally.

## New demo

A `<position-anchor-on-host>` custom element is added to `shadow-dom.html`. Its `connectedCallback` wires up the anchor link at runtime:

```html
<div id="anchor" class="anchor">Anchor</div>
<position-anchor-on-host for="anchor">Target</position-anchor-on-host>
<script>
class PositionAnchorOnHost extends HTMLElement {
  connectedCallback() {
    const targetId = this.getAttribute("for"),
      target = targetId && this.getRootNode().getElementById(targetId);

    this.setAttribute("style", "position-anchor: --position-anchor-on-host");
    target?.setAttribute("style", "anchor-name: --position-anchor-on-host");

    this.attachShadow({ mode: "open" });

    const sheet = new CSSStyleSheet();
    sheet.replaceSync(`
      :host {
        top: anchor(top);
        left: anchor(center);
        position: absolute;
        translate: -50% -100%;
      }
    `);
    this.shadowRoot.adoptedStyleSheets = [sheet];
    this.shadowRoot.innerHTML = "<slot></slot>";
  }
}
customElements.define("position-anchor-on-host", PositionAnchorOnHost);
</script>
```