### PR TITLE
Add `inset: auto` to a polyfilled popover

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ following features:
     containing block. In other words, a polyfilled target may be placed in a
     `position-area` grid section outside its containing block, where the
     implementation would move the target inside the containing block.
+  - For `popover` targets, the browser promotes the element to the top layer
+    when it is shown, which makes the viewport (not the wrapper) its containing
+    block. To work around this, the polyfill strips any non-`auto` inset from
+    the target (setting `inset: auto`) and re-applies it as padding on the
+    wrapper, so the wrapper continues to drive positioning.
 
 In addition, JS APIs like `CSSPositionTryRule` or `CSS.supports` will not be
 polyfilled.

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     <link rel="stylesheet" href="/anchor-positioning.css" />
     <link rel="stylesheet" href="/anchor-inset.css" />
     <link rel="stylesheet" href="/anchor-popover.css" />
+    <link rel="stylesheet" href="/anchor-popover-position-area.css" />
     <link rel="stylesheet" href="/position-try.css" />
     <link rel="stylesheet" href="/position-try-tactics.css" />
     <link rel="stylesheet" href="/position-try-tactics-combined.css" />
@@ -663,6 +664,48 @@
   position: absolute;
   left: anchor(--my-anchor-popover right);
   top: anchor(--my-anchor-popover bottom);
+}</code></pre>
+    </section>
+    <section id="anchor-positioning-popover-position-area" class="demo-item">
+      <h2>
+        <a href="#anchor-positioning-popover-position-area" aria-hidden="true">🔗</a>
+        Anchoring a <code>popover</code> with <code>position-area</code>
+      </h2>
+      <div style="position: relative" class="demo-elements">
+        <button
+          id="my-anchor-popover-position-area"
+          class="anchor"
+          popovertarget="my-target-popover-position-area"
+        >
+          Anchor (click to open)
+        </button>
+        <div id="my-target-popover-position-area" class="target" popover>
+          Popover (Target)
+        </div>
+      </div>
+      <div class="note">
+        <p>
+          With polyfill applied: Target is positioned below the Anchor, aligned
+          to its bottom right corner.
+        </p>
+        <p>
+          <strong>Note:</strong> The polyfill does not create an implicit anchor
+          on buttons that open the popover, so you will need to explicitly add
+          an <code>anchor-name</code> to the triggering button, and refer to it
+          from the positioned element.
+        </p>
+      </div>
+      <pre><code class="language-css"
+>#my-anchor-popover-position-area {
+  position: absolute;
+  left: 200px;
+  anchor-name: --my-anchor-popover-position-area;
+}
+
+#my-target-popover-position-area {
+  position: absolute;
+  position-anchor: --my-anchor-popover-position-area;
+  position-area: end;
 }</code></pre>
     </section>
     <section id="custom-prop-name" class="demo-item">

--- a/index.html
+++ b/index.html
@@ -735,7 +735,7 @@
 }
 
 #my-target-popover-position-area {
-  position: absolute;
+  inset: 10px 5%;
   position-anchor: --my-anchor-popover-position-area;
   position-area: end;
 }</code></pre>

--- a/index.html
+++ b/index.html
@@ -668,7 +668,9 @@
     </section>
     <section id="anchor-positioning-popover-position-area" class="demo-item">
       <h2>
-        <a href="#anchor-positioning-popover-position-area" aria-hidden="true">🔗</a>
+        <a href="#anchor-positioning-popover-position-area" aria-hidden="true"
+          >🔗</a
+        >
         Anchoring a <code>popover</code> with <code>position-area</code>
       </h2>
       <div style="position: relative" class="demo-elements">

--- a/position-area.html
+++ b/position-area.html
@@ -121,6 +121,14 @@
         to stay within its containing block in supporting browsers.
       </p>
       <p>
+        For <code>popover</code> targets, the browser promotes the element to
+        the top layer when it is shown, making the viewport (not the wrapper)
+        its containing block. The polyfill compensates by stripping any
+        non-<code>auto</code> inset from the target (setting
+        <code>inset: auto</code>) and re-applying it as padding on the wrapper,
+        so the wrapper continues to drive positioning.
+      </p>
+      <p>
         <strong>Note: </strong>We strive to keep the polyfill up-to-date with
         ongoing changes to the spec, and we welcome
         <a

--- a/public/anchor-popover-position-area.css
+++ b/public/anchor-popover-position-area.css
@@ -7,6 +7,7 @@
 #my-target-popover-position-area {
   position: absolute;
   margin: 0;
+  inset: 10px;
   position-anchor: --my-anchor-popover-position-area;
   position-area: end;
 }

--- a/public/anchor-popover-position-area.css
+++ b/public/anchor-popover-position-area.css
@@ -5,9 +5,7 @@
 }
 
 #my-target-popover-position-area {
-  position: absolute;
-  margin: 0;
-  inset: 10px;
+  inset: 10px 5%;
   position-anchor: --my-anchor-popover-position-area;
   position-area: end;
 }

--- a/public/anchor-popover-position-area.css
+++ b/public/anchor-popover-position-area.css
@@ -1,0 +1,12 @@
+#my-anchor-popover-position-area {
+  position: absolute;
+  left: 200px;
+  anchor-name: --my-anchor-popover-position-area;
+}
+
+#my-target-popover-position-area {
+  position: absolute;
+  margin: 0;
+  position-anchor: --my-anchor-popover-position-area;
+  position-area: end;
+}

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -554,8 +554,13 @@ export function wrapperForPositionedElement(
     wrapperEl.style.pointerEvents = 'none';
     targetEl.style.pointerEvents = originalPointerEvents;
 
-    // The wrapper sets the inset values, so the target should not have them.
-    targetEl.style.inset = 'auto';
+    // A popover in the top layer receives `inset: 0` from the UA stylesheet,
+    // which would conflict with the wrapper-based positioning. Reset it so the
+    // wrapper's inset values take effect. Non-popover targets already default to
+    // `inset: auto`, so this is only needed for popovers.
+    if (targetEl.hasAttribute('popover')) {
+      targetEl.style.inset = 'auto';
+    }
 
     ['top', 'left', 'right', 'bottom'].forEach((prop) => {
       wrapperEl.style.setProperty(prop, `var(--pa-value-${prop})`);

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -562,8 +562,7 @@ export function wrapperForPositionedElement(
     // off the target so the wrapper drives positioning, and re-apply any author
     // offset as padding on the wrapper. Because the wrapper represents the
     // `position-area` cell and the target is aligned within it, padding shrinks
-    // the cell and offsets the target inward — matching `inset` semantics. The
-    // UA's `inset: 0` resolves to zero padding, so it is a no-op. Non-popover
+    // the cell and offsets the target inward — matching `inset` semantics. Non-popover
     // targets stay in this wrapper's containing block, so their own `inset`
     // already works and is left untouched.
     if (targetEl.hasAttribute('popover')) {

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -567,6 +567,7 @@ export function wrapperForPositionedElement(
     // already works and is left untouched.
     if (targetEl.hasAttribute('popover')) {
       const targetStyles = getComputedStyle(targetEl);
+     // Logical insets can also be retrieved via their physical equivalents, so we don't need to loop through those as well.
       (['top', 'right', 'bottom', 'left'] as const).forEach((side) => {
         const value = targetStyles[side];
         if (value && value !== 'auto' && parseFloat(value) !== 0) {

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -567,7 +567,8 @@ export function wrapperForPositionedElement(
     // already works and is left untouched.
     if (targetEl.hasAttribute('popover')) {
       const targetStyles = getComputedStyle(targetEl);
-     // Logical insets can also be retrieved via their physical equivalents, so we don't need to loop through those as well.
+      // Logical insets can also be retrieved via their physical equivalents, so
+      // we don't need to loop through those as well.
       (['top', 'right', 'bottom', 'left'] as const).forEach((side) => {
         const value = targetStyles[side];
         if (value && value !== 'auto' && parseFloat(value) !== 0) {

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -554,11 +554,26 @@ export function wrapperForPositionedElement(
     wrapperEl.style.pointerEvents = 'none';
     targetEl.style.pointerEvents = originalPointerEvents;
 
-    // A popover in the top layer receives `inset: 0` from the UA stylesheet,
-    // which would conflict with the wrapper-based positioning. Reset it so the
-    // wrapper's inset values take effect. Non-popover targets already default to
-    // `inset: auto`, so this is only needed for popovers.
+    // When a popover is shown it is promoted to the top layer, so its
+    // containing block becomes the viewport rather than this wrapper. That means
+    // any non-`auto` `inset` on the popover — the UA stylesheet's `inset: 0`, or
+    // an author value such as `inset: 10px` — pins it to the viewport instead of
+    // letting it take its place inside the wrapper's grid cell. Strip the inset
+    // off the target so the wrapper drives positioning, and re-apply any author
+    // offset as padding on the wrapper. Because the wrapper represents the
+    // `position-area` cell and the target is aligned within it, padding shrinks
+    // the cell and offsets the target inward — matching `inset` semantics. The
+    // UA's `inset: 0` resolves to zero padding, so it is a no-op. Non-popover
+    // targets stay in this wrapper's containing block, so their own `inset`
+    // already works and is left untouched.
     if (targetEl.hasAttribute('popover')) {
+      const targetStyles = getComputedStyle(targetEl);
+      (['top', 'right', 'bottom', 'left'] as const).forEach((side) => {
+        const value = targetStyles[side];
+        if (value && value !== 'auto' && parseFloat(value) !== 0) {
+          wrapperEl.style.setProperty(`padding-${side}`, value);
+        }
+      });
       targetEl.style.inset = 'auto';
     }
 

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -554,6 +554,9 @@ export function wrapperForPositionedElement(
     wrapperEl.style.pointerEvents = 'none';
     targetEl.style.pointerEvents = originalPointerEvents;
 
+    // The wrapper sets the inset values, so the target should not have them.
+    targetEl.style.inset = 'auto';
+
     ['top', 'left', 'right', 'bottom'].forEach((prop) => {
       wrapperEl.style.setProperty(prop, `var(--pa-value-${prop})`);
     });


### PR DESCRIPTION
Closes #330 

Fixes positioning of polyfilled popovers that use `position-area` by explicitly setting `inset: auto` on the target element inside the wrapper. Without this, the browser's default `inset` values on `[popover]` elements conflict with the wrapper-based positioning approach.

Also adds a demo example to `index.html` showing a popover anchored via `position-area` instead of `anchor()`.