### PR TITLE
Handle positioned elements with fixed positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -625,7 +625,7 @@
 }</code></pre>
     </section>
 
-    <section id="fixed-target" class="demo-item">
+    <section id="fixed" class="demo-item">
       <h2>
         <a href="#fixed" aria-hidden="true">🔗</a>
         Positioning fixed position target

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <link rel="stylesheet" href="/anchor-inside-outside.css" />
     <link rel="stylesheet" href="/import-has-import.css" />
     <link rel="stylesheet" href="/invalid-anchor.css" />
+    <link rel="stylesheet" href="/anchor-fixed.css" />
     <!-- Included to test invalid stylesheets -->
     <link rel="stylesheet" href="/fake.css" />
     <style>
@@ -623,6 +624,50 @@
   anchor-name: --my-position-anchor-b;
 }</code></pre>
     </section>
+
+    <section id="fixed-target" class="demo-item">
+      <h2>
+        <a href="#position-anchor" aria-hidden="true">🔗</a>
+        Positioning fixed position target
+      </h2>
+      <div style="position: relative" class="demo-elements">
+        <div id="my-fixed-position-anchor" class="anchor">Anchor A</div>
+        <div id="my-fixed-position-target" class="target">Target A</div>
+      </div>
+      <p class="note">
+        With polyfill applied: Targets are positioned at the top right corner of
+        their respective Anchors.
+      </p>
+      <pre><code class="language-html"
+>&lt;div id="my-position-anchor-a" class="anchor"&gt;Anchor A&lt;/div&gt;
+&lt;div id="my-position-target-a" class="target"&gt;Target A&lt;/div&gt;
+&lt;div id="my-position-anchor-b" class="anchor"&gt;Anchor B&lt;/div&gt;
+&lt;div id="my-position-target-b" class="target"&gt;Target B&lt;/div&gt;</code>
+
+<code class="language-css"
+>#my-position-target-a {
+  position-anchor: --my-position-anchor-a;
+}
+
+#my-position-target-b {
+  position-anchor: --my-position-anchor-b;
+}
+
+.target {
+  position: absolute;
+  bottom: anchor(top);
+  left: anchor(right);
+}
+
+#my-position-anchor-a {
+  anchor-name: --my-position-anchor-a;
+}
+
+#my-position-anchor-b {
+  anchor-name: --my-position-anchor-b;
+}</code></pre>
+    </section>
+
     <section id="anchor-positioning-popover" class="demo-item">
       <h2>
         <a href="#anchor-positioning-popover" aria-hidden="true">🔗</a>

--- a/index.html
+++ b/index.html
@@ -654,13 +654,11 @@
       </div>
       <pre><code class="language-css"
 >#my-anchor-popover {
-  position: absolute;
-  left: 200px;
   anchor-name: --my-anchor-popover;
 }
 
 #my-target-popover {
-  position: absolute;
+  margin: initial;
   left: anchor(--my-anchor-popover right);
   top: anchor(--my-anchor-popover bottom);
 }</code></pre>

--- a/index.html
+++ b/index.html
@@ -627,44 +627,31 @@
 
     <section id="fixed-target" class="demo-item">
       <h2>
-        <a href="#position-anchor" aria-hidden="true">🔗</a>
+        <a href="#fixed" aria-hidden="true">🔗</a>
         Positioning fixed position target
       </h2>
       <div style="position: relative" class="demo-elements">
-        <div id="my-fixed-position-anchor" class="anchor">Anchor A</div>
-        <div id="my-fixed-position-target" class="target">Target A</div>
+        <div id="my-fixed-position-anchor" class="anchor">Anchor</div>
+        <div id="my-fixed-position-target" class="target">Fixed Target</div>
       </div>
       <p class="note">
-        With polyfill applied: Targets are positioned at the top right corner of
-        their respective Anchors.
+        With polyfill applied: Target is positioned at the bottom right corner
+        of the Anchor.
       </p>
       <pre><code class="language-html"
->&lt;div id="my-position-anchor-a" class="anchor"&gt;Anchor A&lt;/div&gt;
-&lt;div id="my-position-target-a" class="target"&gt;Target A&lt;/div&gt;
-&lt;div id="my-position-anchor-b" class="anchor"&gt;Anchor B&lt;/div&gt;
-&lt;div id="my-position-target-b" class="target"&gt;Target B&lt;/div&gt;</code>
+>&lt;div id="my-fixed-position-anchor" class="anchor"&gt;Anchor&lt;/div&gt;
+&lt;div id="my-fixed-position-target" class="target"&gt;Fixed Target&lt;/div&gt;</code>
 
 <code class="language-css"
->#my-position-target-a {
-  position-anchor: --my-position-anchor-a;
+>#my-fixed-position-anchor {
+  anchor-name: --my-fixed-position-anchor;
 }
 
-#my-position-target-b {
-  position-anchor: --my-position-anchor-b;
-}
-
-.target {
-  position: absolute;
-  bottom: anchor(top);
+#my-fixed-position-target {
+  position: fixed;
+  position-anchor: --my-fixed-position-anchor;
+  top: anchor(bottom);
   left: anchor(right);
-}
-
-#my-position-anchor-a {
-  anchor-name: --my-position-anchor-a;
-}
-
-#my-position-anchor-b {
-  anchor-name: --my-position-anchor-b;
 }</code></pre>
     </section>
 

--- a/position-area.html
+++ b/position-area.html
@@ -423,6 +423,17 @@
       </div>
     </section>
 
+    <section class="position-area-demo-item" id="fixed">
+      <h2>
+        <a href="#fixed" aria-hidden="true">🔗</a>
+        <code>fixed ✅</code>
+      </h2>
+      <div style="position: relative" class="demo-elements">
+        <div class="anchor">Anchor</div>
+        <div class="target fixed">Target</div>
+      </div>
+    </section>
+
     <section class="position-area-demo-item" id="no-block-space">
       <h2>
         <a href="#no-block-space" aria-hidden="true">🔗</a>

--- a/public/anchor-fixed.css
+++ b/public/anchor-fixed.css
@@ -1,0 +1,10 @@
+#my-fixed-position-anchor {
+  anchor-name: --my-fixed-position-anchor;
+}
+
+#my-fixed-position-target {
+  position: fixed;
+  position-anchor: --my-fixed-position-anchor;
+  top: anchor(bottom);
+  left: anchor(right);
+}

--- a/public/anchor-popover.css
+++ b/public/anchor-popover.css
@@ -1,12 +1,9 @@
 #my-anchor-popover {
-  position: absolute;
-  left: 200px;
   anchor-name: --my-anchor-popover;
 }
 
 #my-target-popover {
-  position: absolute;
-  margin: 0;
+  margin: initial;
   left: anchor(--my-anchor-popover right);
   top: anchor(--my-anchor-popover bottom);
 }

--- a/public/position-area-page.css
+++ b/public/position-area-page.css
@@ -129,3 +129,8 @@
   background: repeating-linear-gradient(45deg, #ccc 0 5px, transparent 0 10px);
   outline: 1pt dotted var(--brand-orange);
 }
+
+.target.fixed {
+  position: fixed;
+  position-area: end;
+}

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -32,7 +32,11 @@ import {
   type SizingProperty,
 } from './syntax.js';
 import { transformCSS } from './transform.js';
-import { reportParseErrorsOnFailure, resetParseErrors } from './utils.js';
+import {
+  reportParseErrorsOnFailure,
+  resetParseErrors,
+  strategyForElement,
+} from './utils.js';
 
 const platformWithCache = { ...platform, _c: new Map() };
 
@@ -322,6 +326,7 @@ async function applyAnchorPositions(
       const anchor = anchorValue.anchorEl;
       const target = anchorValue.targetEl;
       if (anchor && target) {
+        const strategy = strategyForElement(target);
         if (isPositionAreaTarget(anchorValue)) {
           const wrapper = anchorValue.wrapperEl!;
           const getPositionAreaPixelValue = async (
@@ -355,7 +360,9 @@ async function applyAnchorPositions(
               const rects = await platform.getElementRects({
                 reference: anchor,
                 floating: wrapper,
-                strategy: 'absolute',
+                // Use the strategy for the wrapper, which should match the
+                // target it wraps.
+                strategy: strategyForElement(wrapper),
               });
               const insets = anchorValue.insets;
 
@@ -415,7 +422,7 @@ async function applyAnchorPositions(
               const rects = await platform.getElementRects({
                 reference: anchor,
                 floating: target,
-                strategy: 'absolute',
+                strategy,
               });
               const resolved = await getPixelValue({
                 targetEl: target,
@@ -448,7 +455,7 @@ async function checkOverflow(target: HTMLElement, offsetParent: HTMLElement) {
   const rects = await platform.getElementRects({
     reference: target,
     floating: target,
-    strategy: 'absolute',
+    strategy: strategyForElement(target),
   });
   const overflow = await detectOverflow(
     {
@@ -460,7 +467,7 @@ async function checkOverflow(target: HTMLElement, offsetParent: HTMLElement) {
         floating: target,
         reference: offsetParent,
       },
-      strategy: 'absolute',
+      strategy: strategyForElement(target),
     } as unknown as MiddlewareState,
     {
       padding: getMargins(target),

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -25,7 +25,7 @@ import { type List } from 'css-tree/utils';
 import { nanoid } from 'nanoid';
 
 import { getOffsetParent, type PseudoElement } from './dom.js';
-import { type DeclarationWithValue } from './utils.js';
+import { type DeclarationWithValue, strategyForElement } from './utils.js';
 
 // Set this value on a target as a sibling to a position area declaration. Then
 // check it to determine which position area declaration should win, if there
@@ -546,7 +546,7 @@ export function wrapperForPositionedElement(
   } else {
     wrapperEl = document.createElement(WRAPPER_ELEMENT);
     wrapperEl.style.display = 'grid';
-    wrapperEl.style.position = 'absolute';
+    wrapperEl.style.position = strategyForElement(targetEl);
 
     // The wrapper should not receive pointer events, but the target's initial
     // `pointer-events` value should be preserved.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { type Strategy } from '@floating-ui/dom';
 import type {
   CssNode,
   Declaration,
@@ -14,7 +15,7 @@ import parse from 'css-tree/parser';
 import { clone } from 'css-tree/utils';
 import { nanoid } from 'nanoid/non-secure';
 
-import type { Selector } from './dom.js';
+import { getCSSPropertyValue, type Selector } from './dom.js';
 
 export const INSTANCE_UUID = nanoid();
 
@@ -185,3 +186,8 @@ export function reportParseErrorsOnFailure() {
 export function resetParseErrors() {
   cssParseErrors.clear();
 }
+
+export const strategyForElement = (el: HTMLElement): Strategy => {
+  const position = getCSSPropertyValue(el, 'position');
+  return position === 'fixed' ? 'fixed' : 'absolute';
+};


### PR DESCRIPTION
## Description
We were always using the `absolute` strategy for Floating UI, which meant that fixed position elements were not positioned correctly. This makes the strategy dynamic, based on the positioning of the positioned element. 

## Related Issue(s)
This relates to #350, and we should check if it fixes that.

## Steps to test/reproduce
Check out [position area](https://deploy-preview-413--anchor-polyfill.netlify.app/position-area.html#fixed) and [anchor](https://deploy-preview-413--anchor-polyfill.netlify.app/#fixed) examples