### PR TITLE
Allow CI to run on external PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ name: Lint & Test
 
 on:
   push:
+    branches: [main]
   pull_request:
-    types: [reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
`push` doesn't run on external forks, so we want to enable `pull_request` to allow CI to run.