### PR TITLE
fix: element removed from the DOM when directly under the shadow root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ apply to which elements on the page.
 ## Development
 
 - Clone the repository.
+- Install [nvm](https://github.com/nvm-sh/nvm) and run `nvm use`.
 - Install dependencies: `npm install`.
 - Start dev server: `npm run serve`. Visit `localhost:3000`.
 

--- a/shadow-dom.html
+++ b/shadow-dom.html
@@ -44,18 +44,16 @@
               }
               .target {
                 position: absolute;
-                right: anchor(--adopted-anchor right, 50px);
-                top: anchor(--adopted-anchor bottom);
+                position-anchor: --adopted-anchor;
+                position-area: bottom span-left;
               }
             `);
             this.shadowRoot.adoptedStyleSheets = [sheet];
 
             this.shadowRoot.innerHTML = `
               <link rel="stylesheet" href="/demo.css" />
-              <div style="position: relative">
-                <div class="target">Target</div>
-                <div class="anchor">Anchor</div>
-              </div>
+              <div class="anchor">Anchor</div>
+              <div class="target">Target</div>
             `;
           }
         }
@@ -289,17 +287,15 @@ class AnchorAdoptedStyles extends HTMLElement {
       }
       .target {
         position: absolute;
-        right: anchor(--adopted-anchor right, 50px);
-        top: anchor(--adopted-anchor bottom);
+        position-anchor: --adopted-anchor;
+        position-area: bottom span-left;
       }
     `);
     this.shadowRoot.adoptedStyleSheets = [sheet];
 
     this.shadowRoot.innerHTML = `
-      &lt;div style="position: relative"&gt;
-        &lt;div class="target"&gt;Target&lt;/div&gt;
-        &lt;div class="anchor"&gt;Anchor&lt;/div&gt;
-      &lt;/div&gt;
+      &lt;div class="target"&gt;Target&lt;/div&gt;
+      &lt;div class="anchor"&gt;Anchor&lt;/div&gt;
     `;
   }
 }

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -581,7 +581,12 @@ export function wrapperForPositionedElement(
     ['top', 'left', 'right', 'bottom'].forEach((prop) => {
       wrapperEl.style.setProperty(prop, `var(--pa-value-${prop})`);
     });
-    targetEl.parentElement?.insertBefore(wrapperEl, targetEl);
+    // Insert the wrapper relative to the target itself rather than going
+    // through its parent: when `targetEl` sits directly inside a shadow root,
+    // `parentElement` is `null` (a `ShadowRoot` is a `Node`, not an `Element`),
+    // which would skip the insert while still appending the target to the
+    // wrapper — detaching it from the DOM entirely.
+    targetEl.insertAdjacentElement('beforebegin', wrapperEl);
     wrapperEl.appendChild(targetEl);
   }
   // Wrapper can be be reused by multiple declarations, so set all as boolean

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -89,7 +89,9 @@ export function transformCSS(
           );
           for (const container of containers) {
             // If there are multiple roots, clone the element for each root
-            const node = styleEl.isConnected ? styleEl : (styleEl.cloneNode(true));
+            const node = styleEl.isConnected
+              ? styleEl
+              : styleEl.cloneNode(true);
             container.append(node);
           }
         }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -87,11 +87,10 @@ export function transformCSS(
           const containers = new Set(
             (roots?.length ? roots : [document]).map(getRootStyleContainer),
           );
-          let first = true;
           for (const container of containers) {
-            const node = first ? styleEl : (styleEl.cloneNode(true) as Element);
+            // If there are multiple roots, clone the element for each root
+            const node = styleEl.isConnected ? styleEl : (styleEl.cloneNode(true));
             container.append(node);
-            first = false;
           }
         }
         updatedObject.el = styleEl;

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -22,6 +22,19 @@ const excludeAttributes = [
   'type',
 ];
 
+// Resolves the node that a polyfill-generated `<style>` should be appended to
+// for a given root, so its rules apply to wrapper elements created within that
+// root. Styles in `document.head` do not pierce into a shadow root, so styles
+// for a shadow root (or an element inside one) must be appended there instead.
+function getRootStyleContainer(
+  root: AnchorPositioningRoot,
+): ShadowRoot | HTMLHeadElement {
+  if (root instanceof ShadowRoot) return root;
+  if (root instanceof Document) return root.head;
+  const rootNode = root.getRootNode();
+  return rootNode instanceof ShadowRoot ? rootNode : document.head;
+}
+
 export function transformCSS(
   styleData: StyleData[],
   inlineStyles?: Map<HTMLElement, Record<string, string>>,
@@ -67,8 +80,19 @@ export function transformCSS(
           el.remove();
         } else {
           styleEl.setAttribute('data-generated-by-polyfill', 'true');
-          // This is a new stylesheet, so we append it.
-          document.head.insertAdjacentElement('beforeend', styleEl);
+          // This is a new stylesheet (the position-area mapping styles). Its
+          // rules target wrapper elements that live inside the roots being
+          // polyfilled, so it must be inserted into each of those roots: a
+          // `<style>` in `document.head` does not apply inside a shadow root.
+          const containers = new Set(
+            (roots?.length ? roots : [document]).map(getRootStyleContainer),
+          );
+          let first = true;
+          for (const container of containers) {
+            const node = first ? styleEl : (styleEl.cloneNode(true) as Element);
+            container.append(node);
+            first = false;
+          }
         }
         updatedObject.el = styleEl;
       } else if (el?.hasAttribute('data-has-inline-styles')) {

--- a/tests/e2e/shadow-dom.test.ts
+++ b/tests/e2e/shadow-dom.test.ts
@@ -62,13 +62,7 @@ test('applies polyfill for adopted stylesheets in shadow root', async ({
   page,
 }) => {
   const anchorSelector = 'anchor-adopted-styles .anchor';
-  const targetSelector = 'anchor-adopted-styles .target';
-  const target = page.locator(targetSelector);
   const anchor = page.locator(anchorSelector);
-  const width = await getElementWidth(page, anchorSelector);
-  const parentWidth = await getParentWidth(page, targetSelector);
-  const parentHeight = await getParentHeight(page, targetSelector);
-  const expected = parentWidth - width;
 
   // The empty value is `""`, so require more than one character.
   const nonEmptyValue = /.+/;
@@ -78,8 +72,29 @@ test('applies polyfill for adopted stylesheets in shadow root', async ({
 
   await applyPolyfill(page);
 
-  await expectWithinOne(target, 'top', parentHeight);
-  await expectWithinOne(target, 'right', expected);
+  // The target uses `position-area: bottom span-left`, so the polyfill wraps it
+  // in a `<polyfill-position-area>` element that carries the position values.
+  const targetWrapper = page.locator(
+    'anchor-adopted-styles POLYFILL-POSITION-AREA',
+  );
+  const target = targetWrapper.locator('.target');
+
+  // `span-left` aligns the inline (x) end; `bottom` aligns the block (y) start.
+  await expect(target).toHaveCSS('justify-self', 'end');
+  await expect(target).toHaveCSS('align-self', 'start');
+  await expectWithinOne(targetWrapper, 'bottom', 0);
+  await expectWithinOne(targetWrapper, 'left', 0);
+
+  const anchorBox = await anchor.boundingBox();
+  const targetWrapperBox = await targetWrapper.boundingBox();
+
+  // Right sides should be aligned.
+  expect(targetWrapperBox!.x + targetWrapperBox!.width).toBeCloseTo(
+    anchorBox!.x + anchorBox!.width,
+    0,
+  );
+  // Target top should be aligned with anchor bottom.
+  expect(targetWrapperBox!.y).toBeCloseTo(anchorBox!.y + anchorBox!.height, 0);
 });
 
 test('positions every custom-element host sharing one constructed stylesheet', async ({


### PR DESCRIPTION
## Problem

When a `position-area` target element sits **directly inside a shadow root**, `wrapperForPositionedElement` failed to wrap it and instead removed it from the DOM entirely.

The wrapping logic was:

```js
targetEl.parentElement?.insertBefore(wrapperEl, targetEl);
wrapperEl.appendChild(targetEl);
```

A `ShadowRoot` is a `Node`, not an `Element`, so `targetEl.parentElement` is `null` when the target is a direct child of the shadow root. The optional chaining short-circuited the `insertBefore`, but the following `wrapperEl.appendChild(targetEl)` still ran — moving the target into a wrapper that was never inserted into the tree. The result: the target disappeared from the rendered DOM.

## Fix

Insert the wrapper relative to the target itself rather than going through its parent:

```js
targetEl.insertAdjacentElement('beforebegin', wrapperEl);
wrapperEl.appendChild(targetEl);
```

`insertAdjacentElement('beforebegin', …)` places the wrapper just before the target without referencing the parent node, so it works whether the parent is a regular element or a shadow root.

## Second fix: `position-area` mapping styles not reaching shadow roots

Even once wrapped, the target wasn't positioned: the generated `position-area` mapping stylesheet (which defines the `--pa-value-*` custom properties on the wrapper) was always appended to `document.head`, and a `<style>` there doesn't apply inside a shadow root. So `--pa-value-*` stayed empty and the wrapper collapsed to its static position.

`transformCSS` now inserts these polyfill-created styles into each polyfilled root via a new `getRootStyleContainer` helper (shadow root → that shadow root; document → `document.head`). The wrapper now resolves its insets and alignment correctly inside a shadow root.

## Test page

Updated `shadow-dom.html` to reproduce the scenario: the target/anchor now live directly under the shadow root (no intermediate `position: relative` wrapper) and use `position-area` syntax, which exercises the wrapping code path. The adopted-stylesheets e2e test now asserts against the `<polyfill-position-area>` wrapper (right edges aligned, target top at anchor bottom).
