### PR TITLE
Add padding to demo elements, mark non-working example

### DIFF
--- a/index.html
+++ b/index.html
@@ -717,8 +717,9 @@
       </div>
       <div class="note">
         <p>
-          With polyfill applied: Target is positioned below the Anchor, aligned
-          to its bottom right corner.
+          With polyfill applied: Target is positioned below and to the right of
+          the Anchor. Its containing block is aligned to its bottom right
+          corner, adjusted with <code>inset: 10px 5%</code>.
         </p>
         <p>
           <strong>Note:</strong> The polyfill does not create an implicit anchor
@@ -795,9 +796,9 @@
     <section id="position-try-tactics" class="demo-item">
       <h2>
         <a href="#position-try-tactics" aria-hidden="true">🔗</a>
-        Fallbacks with <code>position-try-fallbacks</code>
+        Fallbacks with <code>position-try-fallbacks</code> ⚠️
       </h2>
-      <div style="position: relative" class="demo-elements">
+      <div style="position: relative" class="demo-elements tight">
         <div class="scroll-container">
           <div class="placefiller-above-anchor"></div>
           <div class="placefiller-before-anchor"></div>
@@ -813,6 +814,10 @@
         </div>
       </div>
       <div class="note">
+        <p>
+          <strong>⚠️ Note: </strong>This example is broken in both polyfilled
+          and non-polyfilled browsers.
+        </p>
         <p>
           With polyfill applied, the following positions are attempted in order:
         </p>
@@ -880,7 +885,7 @@
         Fallbacks with <code>position-try-fallbacks</code> and
         <code>@position-try</code>
       </h2>
-      <div style="position: relative" class="demo-elements">
+      <div style="position: relative" class="demo-elements tight">
         <div class="scroll-container">
           <div class="placefiller-above-anchor"></div>
           <div class="placefiller-before-anchor"></div>
@@ -987,7 +992,7 @@
         <a href="#position-try-tactics-combined" aria-hidden="true">🔗</a>
         Positioning with combined try tactics
       </h2>
-      <div style="position: relative" class="demo-elements">
+      <div style="position: relative" class="demo-elements tight">
         <div class="scroll-container">
           <div class="placefiller-above-anchor"></div>
           <div class="placefiller-before-anchor"></div>
@@ -1048,7 +1053,7 @@
         <a href="#anchor-scroll" aria-hidden="true">🔗</a>
         Positioning with <code>anchor()</code> [scrolling elements]
       </h2>
-      <div style="position: relative" class="demo-elements">
+      <div style="position: relative" class="demo-elements tight">
         <div class="scroll-container">
           <div class="placefiller-above-anchor"></div>
           <div class="placefiller-before-anchor"></div>
@@ -1375,7 +1380,7 @@
         <a href="#anchor-pseudo-element" aria-hidden="true">🔗</a>
         Pseudo-element anchor
       </h2>
-      <div style="position: relative" class="demo-elements">
+      <div style="position: relative" class="demo-elements tight">
         <div class="scroll-container">
           <div class="placefiller-above-anchor"></div>
           <div class="placefiller-before-anchor"></div>
@@ -1450,7 +1455,7 @@
           Polyfill target 1 and 3
         </button>
       </div>
-      <div class="demo-elements">
+      <div class="demo-elements tight">
         <div id="my-anchor-manual" class="anchor">Anchor</div>
         <div id="my-target-manual-style-el" class="target">
           Target 1 (with <code>&lt;style&gt;</code>)
@@ -1518,7 +1523,7 @@ CSS inside the anchor-manual.css file:
         <a href="#anchor-scope" aria-hidden="true">🔗</a>
         Scope an anchor name
       </h2>
-      <div class="demo-elements">
+      <div class="demo-elements tight">
         <ul>
           <li class="anchor">
             <span>List item One</span><span class="arrow">▶</span>
@@ -1626,7 +1631,7 @@ CSS inside the anchor-manual.css file:
         <a href="#invalid-anchor" aria-hidden="true">🔗</a>
         Invalid anchor
       </h2>
-      <div class="demo-elements">
+      <div class="demo-elements tight">
         <div id="my-target-invalid" class="target">Target</div>
       </div>
       <p class="note">

--- a/public/demo.css
+++ b/public/demo.css
@@ -180,6 +180,11 @@ footer p {
   font-family: var(--font-sans);
 }
 
+.demo-elements:not(.tight) {
+  /* Sync with DEMO_ELEMENT_PADDING in polyfill.test.ts */
+  padding: 30px;
+}
+
 .note {
   background-color: var(--callout);
   border-inline-start: 0.5em solid var(--note-color);

--- a/tests/e2e/polyfill.test.ts
+++ b/tests/e2e/polyfill.test.ts
@@ -12,6 +12,8 @@ test.beforeEach(async ({ page }) => {
 const btnSelector = '#apply-polyfill';
 const targetSelector = '#my-target-positioning';
 const anchorSelector = '#my-anchor-positioning';
+const DEMO_ELEMENT_PADDING = '30px';
+const DEMO_ELEMENT_PADDING_NUMBER = 30;
 
 async function applyPolyfill(page: Page) {
   const btn = page.locator(btnSelector);
@@ -53,13 +55,21 @@ test('applies polyfill for `anchor()`', async ({ page }) => {
   const parentHeight = await getParentHeight(page, targetSelector);
   const expected = parentWidth - width;
 
-  await expect(target).toHaveCSS('top', '0px');
+  await expect(target).toHaveCSS('top', DEMO_ELEMENT_PADDING);
   await expectWithinOne(target, 'right', expected, true);
 
   await applyPolyfill(page);
 
-  await expectWithinOne(target, 'top', parentHeight);
-  await expectWithinOne(target, 'right', expected);
+  await expectWithinOne(
+    target,
+    'top',
+    parentHeight - DEMO_ELEMENT_PADDING_NUMBER,
+  );
+  await expectWithinOne(
+    target,
+    'right',
+    expected - DEMO_ELEMENT_PADDING_NUMBER,
+  );
 });
 
 test('applies polyfill for inside and outside keywords', async ({ page }) => {
@@ -71,13 +81,21 @@ test('applies polyfill for inside and outside keywords', async ({ page }) => {
   const parentHeight = await getParentHeight(page, inoutTargetSelector);
   const expected = parentHeight - height;
 
-  await expectWithinOne(target, 'left', 0);
+  await expectWithinOne(target, 'left', DEMO_ELEMENT_PADDING_NUMBER);
   await expectWithinOne(target, 'bottom', expected, true);
 
   await applyPolyfill(page);
 
-  await expectWithinOne(target, 'left', parentWidth);
-  await expectWithinOne(target, 'bottom', expected);
+  await expectWithinOne(
+    target,
+    'left',
+    parentWidth - DEMO_ELEMENT_PADDING_NUMBER,
+  );
+  await expectWithinOne(
+    target,
+    'bottom',
+    expected + DEMO_ELEMENT_PADDING_NUMBER,
+  );
 });
 
 test('applies polyfill for inset- full longhands', async ({ page }) => {
@@ -151,13 +169,21 @@ test('applies polyfill from inline styles', async ({ page }) => {
   const parentHeight = await getParentHeight(page, targetSelector);
   const expected = parentWidth - width;
 
-  await expect(targetInLine).toHaveCSS('top', '0px');
+  await expect(targetInLine).toHaveCSS('top', DEMO_ELEMENT_PADDING);
   await expectWithinOne(targetInLine, 'right', expected, true);
 
   await applyPolyfill(page);
 
-  await expectWithinOne(targetInLine, 'top', parentHeight);
-  await expectWithinOne(targetInLine, 'right', expected);
+  await expectWithinOne(
+    targetInLine,
+    'top',
+    parentHeight - DEMO_ELEMENT_PADDING_NUMBER,
+  );
+  await expectWithinOne(
+    targetInLine,
+    'right',
+    expected - DEMO_ELEMENT_PADDING_NUMBER,
+  );
 });
 
 test('updates when sizes change', async ({ page }) => {
@@ -167,14 +193,26 @@ test('updates when sizes change', async ({ page }) => {
   const parentHeight = await getParentHeight(page, targetSelector);
   await applyPolyfill(page);
 
-  await expectWithinOne(target, 'top', parentHeight);
-  await expectWithinOne(target, 'right', parentWidth - width);
+  await expectWithinOne(
+    target,
+    'top',
+    parentHeight - DEMO_ELEMENT_PADDING_NUMBER,
+  );
+  await expectWithinOne(
+    target,
+    'right',
+    parentWidth - width - DEMO_ELEMENT_PADDING_NUMBER,
+  );
 
   await page
     .locator(anchorSelector)
     .evaluate((anchor) => (anchor.style.width = '50px'));
 
-  await expectWithinOne(target, 'right', parentWidth - 50);
+  await expectWithinOne(
+    target,
+    'right',
+    parentWidth - 50 - DEMO_ELEMENT_PADDING_NUMBER,
+  );
 });
 
 test('applies polyfill for `@position-fallback`', async ({ page }) => {


### PR DESCRIPTION
## Description
Some examples were appearing different due to lack of space around a containing block, and the changes from safe alignment here- https://anchor-positioning.oddbird.net/position-area#no-block-space

I also noted an example that no longer works in polyfilled and non-polyfilled environments. 