### PR TITLE
Move alignment props to child

### DIFF
--- a/position-area.html
+++ b/position-area.html
@@ -183,6 +183,20 @@
       </div>
     </section>
 
+    <section class="position-area-demo-item" id="nested-alignment">
+      <h2>
+        <a href="#nested-alignment" aria-hidden="true">🔗</a>
+        <code>alignment does not leak to descendants ✅</code>
+      </h2>
+      <div style="position: relative" class="demo-elements">
+        <div class="anchor">Anchor</div>
+        <div class="target spanleft-top" id="nested-alignment-target">
+          Target
+          <span id="nested-alignment-descendant">Nested descendant</span>
+        </div>
+      </div>
+    </section>
+
     <section class="position-area-demo-item" id="center-left">
       <h2>
         <a href="#center-left" aria-hidden="true">🔗</a>

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -54,6 +54,7 @@ import {
   type DeclarationWithValue,
   INSTANCE_UUID,
   PA_INSET_SIDES,
+  type PaValueProp,
   paValueProperties,
   paWrapperProperties,
   strategyForElement,
@@ -637,7 +638,7 @@ export function addPositionAreaDeclarationBlockStyles(
       appendDeclaration(prop, `var(${paValueProperties.get(prop)}, auto)`),
     );
   } else {
-    const props = positionAreaContainingBlock
+    const props: PaValueProp[] = positionAreaContainingBlock
       ? // Insets are applied to a wrapping element
         ['justify-self', 'align-self']
       : // Insets are applied to the target itself

--- a/src/position-area.ts
+++ b/src/position-area.ts
@@ -54,8 +54,8 @@ import {
   type DeclarationWithValue,
   INSTANCE_UUID,
   PA_INSET_SIDES,
-  paValueProperty,
-  paWrapperProperty,
+  paValueProperties,
+  paWrapperProperties,
   strategyForElement,
 } from './utils.js';
 
@@ -627,14 +627,14 @@ export function addPositionAreaDeclarationBlockStyles(
     // receives the inset values (the alignments fall back to `normal`).
     appendDeclaration(
       'justify-self',
-      `var(${paValueProperty('justify-self')}, normal)`,
+      `var(${paValueProperties.get('justify-self')}, normal)`,
     );
     appendDeclaration(
       'align-self',
-      `var(${paValueProperty('align-self')}, normal)`,
+      `var(${paValueProperties.get('align-self')}, normal)`,
     );
     PA_INSET_SIDES.forEach((prop) =>
-      appendDeclaration(prop, `var(${paValueProperty(prop)}, auto)`),
+      appendDeclaration(prop, `var(${paValueProperties.get(prop)}, auto)`),
     );
   } else {
     const props = positionAreaContainingBlock
@@ -643,7 +643,7 @@ export function addPositionAreaDeclarationBlockStyles(
       : // Insets are applied to the target itself
         [...PA_INSET_SIDES];
     props.forEach((prop) =>
-      appendDeclaration(prop, `var(${paValueProperty(prop)})`),
+      appendDeclaration(prop, `var(${paValueProperties.get(prop)})`),
     );
   }
   appendDeclaration(POSITION_AREA_CASCADE_PROPERTY, declaration.selectorUUID);
@@ -696,7 +696,10 @@ export function wrapperForPositionedElement(
     // with an `auto` fallback; using `--pa-wrapper-*` here keeps the wrapper's
     // inset values from being inherited by the target as its own insets.
     PA_INSET_SIDES.forEach((prop) => {
-      wrapperEl.style.setProperty(prop, `var(${paWrapperProperty(prop)})`);
+      wrapperEl.style.setProperty(
+        prop,
+        `var(${paWrapperProperties.get(prop)})`,
+      );
     });
     // Insert the wrapper relative to the target itself rather than going
     // through its parent: when `targetEl` sits directly inside a shadow root,
@@ -791,20 +794,22 @@ export async function dataForPositionAreaTarget(
 
 export function activeWrapperStyles(targetUUID: string, selectorUUID: string) {
   const insets = PA_INSET_SIDES.map(
-    (side) => `${paWrapperProperty(side)}: var(${targetUUID}-${side});`,
+    (side) => `${paWrapperProperties.get(side)}: var(${targetUUID}-${side});`,
   ).join('\n      ');
   return `
     [${POSITION_AREA_WRAPPER_ATTRIBUTE}="${selectorUUID}"][${WRAPPER_TARGET_ATTRIBUTE_PRELUDE}${targetUUID}] {
       ${insets}
-      ${paValueProperty('justify-self')}: var(${targetUUID}-justify-self);
-      ${paValueProperty('align-self')}: var(${targetUUID}-align-self);
+    }
+    [${POSITION_AREA_WRAPPER_ATTRIBUTE}="${selectorUUID}"][${WRAPPER_TARGET_ATTRIBUTE_PRELUDE}${targetUUID}] > * {
+      ${paValueProperties.get('justify-self')}: var(${targetUUID}-justify-self);
+      ${paValueProperties.get('align-self')}: var(${targetUUID}-align-self);
     }
   `.replaceAll('\n', '');
 }
 
 export function activeTargetStyles(targetUUID: string, selectorUUID: string) {
   const insets = PA_INSET_SIDES.map(
-    (side) => `${paValueProperty(side)}: var(${targetUUID}-${side});`,
+    (side) => `${paValueProperties.get(side)}: var(${targetUUID}-${side});`,
   ).join('\n      ');
   return `
     [${POSITION_AREA_TARGET_ATTRIBUTE}="${selectorUUID}"][${TARGET_ATTRIBUTE_PRELUDE}${targetUUID}] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -193,30 +193,43 @@ export const POSITION_ANCHOR_PROPERTY = `--position-anchor-${INSTANCE_UUID}`;
 // `position-area.ts`) so `cascade.ts` can register these as non-inherited
 // without importing `position-area.ts` -- that would create a
 // `cascade -> position-area -> dom -> cascade` import cycle.
-export const paValueProperty = (prop: string) =>
-  `--pa-value-${prop}-${INSTANCE_UUID}`;
+const paValueProperty = (prop: string) => `--pa-value-${prop}-${INSTANCE_UUID}`;
 
 // Names the custom properties for a wrapper's insets, so a shared `auto`
 // selector's target insets don't collide.
-export const paWrapperProperty = (prop: string) =>
+const paWrapperProperty = (prop: string) =>
   `--pa-wrapper-${prop}-${INSTANCE_UUID}`;
 
 // The physical sides the polyfill sets as insets, on the wrapper or (in the
 // unwrapped path) directly on the target.
 export const PA_INSET_SIDES = ['top', 'left', 'right', 'bottom'] as const;
 
+export const paValueProperties = new Map<string, string>([
+  ...PA_INSET_SIDES.map((side): [string, string] => [
+    side,
+    paValueProperty(side),
+  ]),
+  ['justify-self', paValueProperty('justify-self')],
+  ['align-self', paValueProperty('align-self')],
+]);
+
+export const paWrapperProperties = new Map<string, string>(
+  PA_INSET_SIDES.map((side): [string, string] => [
+    side,
+    paWrapperProperty(side),
+  ]),
+);
+
 // Custom properties the polyfill both sets on and reads from the *same* element
 // -- the wrapper's insets, and (in the unwrapped path) the target's insets.
-// These must be registered non-inherited: unlike
-// `--pa-value-{justify,align}-self` (which are set on the wrapper and read on
-// the target child, and so must inherit), an inset set on one `position-area`
+// These must be registered non-inherited: an inset set on one `position-area`
 // target would otherwise leak through inheritance onto a descendant that is
 // itself a `position-area` target, overriding its `auto` fallback. See
 // `registerShiftedProperties` in cascade.ts and
 // https://github.com/oddbird/css-anchor-positioning/issues/279.
 export const NON_INHERITED_POSITION_AREA_PROPERTIES = [
-  ...PA_INSET_SIDES.map((side) => paValueProperty(side)),
-  ...PA_INSET_SIDES.map((side) => paWrapperProperty(side)),
+  ...paValueProperties.values(),
+  ...paWrapperProperties.values(),
 ];
 
 export function splitCommaList(list: List<CssNode>) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -199,18 +199,13 @@ const PA_VALUE_PROPS = [
 ] as const;
 export type PaValueProp = (typeof PA_VALUE_PROPS)[number];
 
-// Names the custom property the polyfill uses to carry a resolved
+// Names the custom properties the polyfill uses to carry a resolved
 // `position-area` value (e.g. `top`, `justify-self`) from the mapping
 // stylesheet to the target or wrapper, and the parallel `--pa-wrapper-*`
 // namespace for a wrapper's insets (so a shared `auto` selector's target insets
-// don't collide). Suffixed with `INSTANCE_UUID` so we don't squat on an
-// author's custom property. Precomputed into Maps (rather than helper
-// functions) so `NON_INHERITED_POSITION_AREA_PROPERTIES` below stays in
-// lockstep with the exact set of names read/written at the call sites; the keys
-// are typed so a mistyped property is a compile error. Exported as
-// `ReadonlyMap` so a consumer can't `.set`/`.delete` and silently desync
-// `NON_INHERITED_POSITION_AREA_PROPERTIES` (snapshotted from `.values()`
-// below).
+// don't collide). Precomputed into Maps so
+// `NON_INHERITED_POSITION_AREA_PROPERTIES` below stays in lockstep with the
+// exact set of names read/written at the call sites.
 export const paValueProperties: ReadonlyMap<PaValueProp, string> = new Map(
   PA_VALUE_PROPS.map((prop) => [prop, `--pa-value-${prop}-${INSTANCE_UUID}`]),
 );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,11 +207,14 @@ export type PaValueProp = (typeof PA_VALUE_PROPS)[number];
 // author's custom property. Precomputed into Maps (rather than helper
 // functions) so `NON_INHERITED_POSITION_AREA_PROPERTIES` below stays in
 // lockstep with the exact set of names read/written at the call sites; the keys
-// are typed so a mistyped property is a compile error.
-export const paValueProperties = new Map<PaValueProp, string>(
+// are typed so a mistyped property is a compile error. Exported as
+// `ReadonlyMap` so a consumer can't `.set`/`.delete` and silently desync
+// `NON_INHERITED_POSITION_AREA_PROPERTIES` (snapshotted from `.values()`
+// below).
+export const paValueProperties: ReadonlyMap<PaValueProp, string> = new Map(
   PA_VALUE_PROPS.map((prop) => [prop, `--pa-value-${prop}-${INSTANCE_UUID}`]),
 );
-export const paWrapperProperties = new Map<PaInsetSide, string>(
+export const paWrapperProperties: ReadonlyMap<PaInsetSide, string> = new Map(
   PA_INSET_SIDES.map((side) => [side, `--pa-wrapper-${side}-${INSTANCE_UUID}`]),
 );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -185,46 +185,43 @@ export function getRootStyleContainer(
 
 export const POSITION_ANCHOR_PROPERTY = `--position-anchor-${INSTANCE_UUID}`;
 
-// Names the custom property the polyfill uses to carry a resolved
-// `position-area` value (e.g. `top`, `justify-self`) from the mapping
-// stylesheet to the target or wrapper. Suffixed with `INSTANCE_UUID` so we
-// don't squat on an author's custom property. Read and write sites all go
-// through this helper so the names can't drift. Lives here (rather than in
-// `position-area.ts`) so `cascade.ts` can register these as non-inherited
-// without importing `position-area.ts` -- that would create a
-// `cascade -> position-area -> dom -> cascade` import cycle.
-const paValueProperty = (prop: string) => `--pa-value-${prop}-${INSTANCE_UUID}`;
-
-// Names the custom properties for a wrapper's insets, so a shared `auto`
-// selector's target insets don't collide.
-const paWrapperProperty = (prop: string) =>
-  `--pa-wrapper-${prop}-${INSTANCE_UUID}`;
-
 // The physical sides the polyfill sets as insets, on the wrapper or (in the
 // unwrapped path) directly on the target.
 export const PA_INSET_SIDES = ['top', 'left', 'right', 'bottom'] as const;
+type PaInsetSide = (typeof PA_INSET_SIDES)[number];
 
-export const paValueProperties = new Map<string, string>([
-  ...PA_INSET_SIDES.map((side): [string, string] => [
-    side,
-    paValueProperty(side),
-  ]),
-  ['justify-self', paValueProperty('justify-self')],
-  ['align-self', paValueProperty('align-self')],
-]);
+// Every property carried through a `--pa-value-*` custom property: the four
+// insets plus the two alignments.
+const PA_VALUE_PROPS = [
+  ...PA_INSET_SIDES,
+  'justify-self',
+  'align-self',
+] as const;
+export type PaValueProp = (typeof PA_VALUE_PROPS)[number];
 
-export const paWrapperProperties = new Map<string, string>(
-  PA_INSET_SIDES.map((side): [string, string] => [
-    side,
-    paWrapperProperty(side),
-  ]),
+// Names the custom property the polyfill uses to carry a resolved
+// `position-area` value (e.g. `top`, `justify-self`) from the mapping
+// stylesheet to the target or wrapper, and the parallel `--pa-wrapper-*`
+// namespace for a wrapper's insets (so a shared `auto` selector's target insets
+// don't collide). Suffixed with `INSTANCE_UUID` so we don't squat on an
+// author's custom property. Precomputed into Maps (rather than helper
+// functions) so `NON_INHERITED_POSITION_AREA_PROPERTIES` below stays in
+// lockstep with the exact set of names read/written at the call sites; the keys
+// are typed so a mistyped property is a compile error.
+export const paValueProperties = new Map<PaValueProp, string>(
+  PA_VALUE_PROPS.map((prop) => [prop, `--pa-value-${prop}-${INSTANCE_UUID}`]),
+);
+export const paWrapperProperties = new Map<PaInsetSide, string>(
+  PA_INSET_SIDES.map((side) => [side, `--pa-wrapper-${side}-${INSTANCE_UUID}`]),
 );
 
-// Custom properties the polyfill both sets on and reads from the *same* element
-// -- the wrapper's insets, and (in the unwrapped path) the target's insets.
-// These must be registered non-inherited: an inset set on one `position-area`
-// target would otherwise leak through inheritance onto a descendant that is
-// itself a `position-area` target, overriding its `auto` fallback. See
+// Custom properties the polyfill both sets on and reads from the *same*
+// element: the wrapper's insets, the target's insets (in the unwrapped path),
+// and the target-child's alignments (`--pa-value-{justify,align}-self`, set on
+// the wrapper's child via the `> *` rule in `activeWrapperStyles`). These must
+// be registered non-inherited: a value set on one `position-area` target would
+// otherwise leak through inheritance onto a descendant that is itself a
+// `position-area` target, overriding its `auto`/`normal` fallback. See
 // `registerShiftedProperties` in cascade.ts and
 // https://github.com/oddbird/css-anchor-positioning/issues/279.
 export const NON_INHERITED_POSITION_AREA_PROPERTIES = [

--- a/tests/e2e/position-area.test.ts
+++ b/tests/e2e/position-area.test.ts
@@ -201,7 +201,16 @@ test('does not leak alignment onto a descendant of a position-area target', asyn
     // Discover the shifted `--pa-value-justify-self-<uuid>` name from the reset.
     const resetText = [...document.head.querySelectorAll('style')]
       .map((el) => el.textContent ?? '')
-      .find((text) => /--pa-value-justify-self-[\w-]+:\s*initial/.test(text))!;
+      .find((text) => /--pa-value-justify-self-[\w-]+:\s*initial/.test(text));
+    // A missing reset is itself the regression under test (the alignment prop
+    // dropped from the non-inherited set); fail with a legible message rather
+    // than a cryptic "Cannot read properties of undefined" from the `.match`.
+    if (!resetText) {
+      throw new Error(
+        'no `--pa-value-justify-self` reset found — likely dropped from ' +
+          'NON_INHERITED_POSITION_AREA_PROPERTIES',
+      );
+    }
     const prop = resetText.match(
       /(--pa-value-justify-self-[\w-]+):\s*initial/,
     )![1];

--- a/tests/e2e/position-area.test.ts
+++ b/tests/e2e/position-area.test.ts
@@ -178,6 +178,55 @@ test('applies logical self properties based on writing mode`', async ({
   );
 });
 
+test('does not leak alignment onto a descendant of a position-area target', async ({
+  page,
+}) => {
+  // The alignment value props (`--pa-value-{justify,align}-self`) are set
+  // directly on the wrapped target's child and registered non-inherited, so a
+  // wrapped target's alignment must not leak onto a descendant (which could
+  // itself be a `position-area` target relying on its own `normal` fallback).
+  // Mirror the inset-leak guard in `polyfill.test.ts` for alignment; exercise
+  // the `CSS.registerProperty`-absent fallback path (the universal `initial`
+  // reset), where a missing reset would let the value inherit. See #438 / #279.
+  await page.addInitScript(() => {
+    delete (CSS as unknown as { registerProperty?: unknown }).registerProperty;
+  });
+  await page.goto('/position-area.html');
+  expect(await page.evaluate(() => typeof CSS.registerProperty)).not.toBe(
+    'function',
+  );
+  await applyPolyfill(page);
+
+  const values = await page.evaluate(() => {
+    // Discover the shifted `--pa-value-justify-self-<uuid>` name from the reset.
+    const resetText = [...document.head.querySelectorAll('style')]
+      .map((el) => el.textContent ?? '')
+      .find((text) => /--pa-value-justify-self-[\w-]+:\s*initial/.test(text))!;
+    const prop = resetText.match(
+      /(--pa-value-justify-self-[\w-]+):\s*initial/,
+    )![1];
+    const target = document.getElementById('nested-alignment-target')!;
+    const wrapper = target.parentElement!; // POLYFILL-POSITION-AREA
+    const descendant = document.getElementById('nested-alignment-descendant')!;
+    const read = (el: Element) =>
+      getComputedStyle(el).getPropertyValue(prop).trim();
+    return {
+      wrapperTag: wrapper.tagName,
+      wrapperValue: read(wrapper),
+      targetValue: read(target),
+      descendantValue: read(descendant),
+    };
+  });
+
+  // The target is wrapped, and its own alignment resolves on the child.
+  expect(values.wrapperTag).toBe('POLYFILL-POSITION-AREA');
+  expect(values.targetValue).toBe('end');
+  // The alignment value prop lives on the child, not the wrapper...
+  expect(values.wrapperValue).toBe('');
+  // ...and does not inherit down to a descendant of the target.
+  expect(values.descendantValue).toBe('');
+});
+
 test.describe('with `positionAreaContainingBlock: false`', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/position-area.html?no-containing-block');

--- a/tests/unit/cascade.test.ts
+++ b/tests/unit/cascade.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   INSTANCE_UUID,
   NON_INHERITED_POSITION_AREA_PROPERTIES,
+  PA_INSET_SIDES,
   type StyleData,
 } from '../../src/utils.js';
 import { cascadeCSSForTest, getSampleCSS } from './../helpers.js';
@@ -39,6 +40,26 @@ describe('registerShiftedProperties', () => {
     for (const property of NON_INHERITED_POSITION_AREA_PROPERTIES) {
       expect(style!.textContent).toContain(`${property}: initial`);
     }
+  });
+
+  it('registers the alignment value props as non-inherited, not just insets', () => {
+    // Regression guard: the alignment value props (`--pa-value-{justify,align}-self`)
+    // must be members of the non-inherited set, alongside the four inset value
+    // props and the four wrapper insets. They used to be excluded (they relied on
+    // inheritance from the wrapper); now they are set directly on the wrapper's
+    // child and must not leak onto a descendant `position-area` target. Dropping
+    // them from this set would reintroduce that leak, so pin the exact membership
+    // here rather than only looping over whatever the array happens to contain.
+    const u = INSTANCE_UUID;
+    const expected = [
+      ...PA_INSET_SIDES.map((side) => `--pa-value-${side}-${u}`),
+      `--pa-value-justify-self-${u}`,
+      `--pa-value-align-self-${u}`,
+      ...PA_INSET_SIDES.map((side) => `--pa-wrapper-${side}-${u}`),
+    ];
+    expect([...NON_INHERITED_POSITION_AREA_PROPERTIES].sort()).toEqual(
+      expected.sort(),
+    );
   });
 });
 

--- a/tests/unit/position-area.test.ts
+++ b/tests/unit/position-area.test.ts
@@ -12,7 +12,13 @@ import {
   markPositionAreaTarget,
   wrapperForPositionedElement,
 } from '../../src/position-area.js';
-import { generateCSS, getAST, INSTANCE_UUID } from '../../src/utils.js';
+import {
+  generateCSS,
+  getAST,
+  INSTANCE_UUID,
+  paValueProperties,
+  paWrapperProperties,
+} from '../../src/utils.js';
 
 const createPositionAreaNode = (input: string[]) => {
   const css = getAST(`a{position-area:${input.join(' ')}}`) as StyleSheet;
@@ -257,6 +263,28 @@ describe('position-area', () => {
       expect(res.insets.inline).toEqual(['right', 0]);
       expect(res.alignments.block).toBe('end');
       expect(res.alignments.inline).toBe('start');
+    });
+  });
+
+  describe('paValueProperties / paWrapperProperties', () => {
+    it('names the value and wrapper custom properties from a single source', () => {
+      const u = INSTANCE_UUID;
+      // `--pa-value-*` covers the four insets plus the two alignments.
+      expect([...paValueProperties]).toEqual([
+        ['top', `--pa-value-top-${u}`],
+        ['left', `--pa-value-left-${u}`],
+        ['right', `--pa-value-right-${u}`],
+        ['bottom', `--pa-value-bottom-${u}`],
+        ['justify-self', `--pa-value-justify-self-${u}`],
+        ['align-self', `--pa-value-align-self-${u}`],
+      ]);
+      // `--pa-wrapper-*` covers only the four insets.
+      expect([...paWrapperProperties]).toEqual([
+        ['top', `--pa-wrapper-top-${u}`],
+        ['left', `--pa-wrapper-left-${u}`],
+        ['right', `--pa-wrapper-right-${u}`],
+        ['bottom', `--pa-wrapper-bottom-${u}`],
+      ]);
     });
   });
 

--- a/tests/unit/position-area.test.ts
+++ b/tests/unit/position-area.test.ts
@@ -263,7 +263,7 @@ describe('position-area', () => {
   describe('activeWrapperStyles', () => {
     it('returns the active styles', () => {
       // Built with `INSTANCE_UUID` rather than a stored snapshot, since the
-      // UUID differs per run (see `paValueProperty`).
+      // UUID differs per run (see `paValueProperties`).
       const u = INSTANCE_UUID;
       expect(activeWrapperStyles('targetUUID', 'selectorUUID')).toBe(
         '    [data-anchor-position-wrapper="selectorUUID"]' +
@@ -272,6 +272,9 @@ describe('position-area', () => {
           `      --pa-wrapper-left-${u}: var(targetUUID-left);` +
           `      --pa-wrapper-right-${u}: var(targetUUID-right);` +
           `      --pa-wrapper-bottom-${u}: var(targetUUID-bottom);` +
+          `    }` +
+          '    [data-anchor-position-wrapper="selectorUUID"]' +
+          '[data-pa-wrapper-for-targetUUID] > * {' +
           `      --pa-value-justify-self-${u}: var(targetUUID-justify-self);` +
           `      --pa-value-align-self-${u}: var(targetUUID-align-self);` +
           '    }  ',


### PR DESCRIPTION
## Description
The wrapper's `justify-self`/`align-self` custom properties (`--pa-value-*`) were being set on the wrapper element itself alongside its inset properties (`--pa-wrapper-*`), relying on CSS inheritance to carry them down to the target child. This sets them directly on the wrapper's child instead, via a `> *` selector, removing that inheritance dependency.

1. activeWrapperStyles in position-area.ts now emits two rule blocks for a wrapper: one on the wrapper itself for insets, and a separate `[wrapper-selector] > *` block for justify-self/align-self, applied directly to the target.
2. paValueProperty/paWrapperProperty in utils.ts are no longer exported as functions; they're now precomputed into paValueProperties/paWrapperProperties Maps. This keeps the used values in sync with NON_INHERITED_POSITION_AREA_PROPERTIES.
