### PR TITLE
fix: missing .d.ts files in dist

### DIFF
--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "..",
     "isolatedModules": false,
     "types": ["vitest/globals"],
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "rootDir": ".",
+    "rootDir": "./src",
     "outDir": "./dist",
     "sourceMap": true
   },


### PR DESCRIPTION
Fixes #440

`package.json` points `types` and `exports` at `dist/index.d.ts` and `dist/index-fn.d.ts`, but `npm run types` was emitting them to `dist/src/` instead, so consumers got no types.

The cause is `rootDir: "."` in `tsconfig.json`. With the root as the base, `tsc` preserves the `src/` path segment in the output, turning `src/index.ts` into `dist/src/index.d.ts`.

Setting `rootDir` to `./src` puts the declarations where `package.json` expects them. `tests/tsconfig.json` extends the root config and includes files outside `src/` (tests and root-level configs), so it overrides `rootDir` back to the project root — it's `noEmit`, so the value only needs to cover its inputs.

`npm run types` now produces `dist/index.d.ts` and `dist/index-fn.d.ts`; `npm run tsc` and `npm run tsc:tests` both pass.