### PR TITLE
fix: pass polyfill options through to constructed-stylesheet shadow runs

### DIFF
--- a/src/shadow.ts
+++ b/src/shadow.ts
@@ -1,4 +1,4 @@
-import { polyfill } from './polyfill.js';
+import { type AnchorPositioningPolyfillOptions, polyfill } from './polyfill.js';
 import { captureAdoptedStylesheetText, originalReplaceSync } from './utils.js';
 
 interface CustomElementHost extends HTMLElement {
@@ -12,22 +12,21 @@ const patchedHosts = new WeakSet<HTMLElement>();
 /**
  * Wraps the `connectedCallback` of a shadow root's host element so that, after
  * the original callback runs (and the shadow DOM is populated), the polyfill is
- * run for that shadow root to position its anchored elements.
+ * run for that shadow root to position its anchored elements, using the options
+ * given to `patchAndPolyfillConstructedStylesheets`.
  */
-function patchHostConnectedCallback(shadowRoot: ShadowRoot) {
+function patchHostConnectedCallback(
+  shadowRoot: ShadowRoot,
+  options: AnchorPositioningPolyfillOptions,
+) {
   const host = shadowRoot.host as CustomElementHost;
   if (patchedHosts.has(host)) {
     return;
   }
   patchedHosts.add(host);
 
-  // Carry over any global options (e.g. `positionAreaContainingBlock`), but
-  // always scope the run to this shadow root.
-  const runPolyfill = () =>
-    polyfill({
-      ...window.ANCHOR_POSITIONING_POLYFILL_OPTIONS,
-      roots: [shadowRoot],
-    });
+  // `roots` is always overridden, to scope the run to this shadow root.
+  const runPolyfill = () => polyfill({ ...options, roots: [shadowRoot] });
 
   const originalConnectedCallback = host.connectedCallback;
   host.connectedCallback = function (this: CustomElementHost) {
@@ -54,8 +53,15 @@ function patchHostConnectedCallback(shadowRoot: ShadowRoot) {
  * Call this as early as possible — before any custom element's
  * `connectedCallback` runs — so that constructed stylesheets are captured and
  * their shadow roots are queued for positioning.
+ *
+ * The given options are passed on to each polyfill run this sets up, except for
+ * `roots`, which is always the shadow root being positioned. Defaults to
+ * `window.ANCHOR_POSITIONING_POLYFILL_OPTIONS`, matching `polyfill()`.
  */
-export function patchAndPolyfillConstructedStylesheets() {
+export function patchAndPolyfillConstructedStylesheets(
+  options: AnchorPositioningPolyfillOptions = window.ANCHOR_POSITIONING_POLYFILL_OPTIONS ??
+    {},
+) {
   // Patch `replaceSync` to capture the source text of constructed stylesheets
   // so the polyfill can later re-parse it.
   if (CSSStyleSheet.prototype.replaceSync === originalReplaceSync) {
@@ -88,7 +94,7 @@ export function patchAndPolyfillConstructedStylesheets() {
       set(this: ShadowRoot, sheets: CSSStyleSheet[]) {
         originalAdoptedStyleSheetsSet.call(this, sheets);
         if (sheets.length > 0) {
-          patchHostConnectedCallback(this);
+          patchHostConnectedCallback(this, options);
         }
       },
     });

--- a/src/shadow.ts
+++ b/src/shadow.ts
@@ -21,10 +21,18 @@ function patchHostConnectedCallback(shadowRoot: ShadowRoot) {
   }
   patchedHosts.add(host);
 
+  // Carry over any global options (e.g. `positionAreaContainingBlock`), but
+  // always scope the run to this shadow root.
+  const runPolyfill = () =>
+    polyfill({
+      ...window.ANCHOR_POSITIONING_POLYFILL_OPTIONS,
+      roots: [shadowRoot],
+    });
+
   const originalConnectedCallback = host.connectedCallback;
   host.connectedCallback = function (this: CustomElementHost) {
     originalConnectedCallback?.call(this);
-    void polyfill({ roots: [shadowRoot] });
+    void runPolyfill();
   };
 
   // If the host is already connected (e.g. `adoptedStyleSheets` was assigned
@@ -33,7 +41,7 @@ function patchHostConnectedCallback(shadowRoot: ShadowRoot) {
   // has finished and the shadow DOM has been populated.
   if (host.isConnected) {
     queueMicrotask(() => {
-      void polyfill({ roots: [shadowRoot] });
+      void runPolyfill();
     });
   }
 }

--- a/tests/e2e/shadow-dom.test.ts
+++ b/tests/e2e/shadow-dom.test.ts
@@ -121,6 +121,64 @@ test('applies global polyfill options to adopted stylesheets in shadow root', as
   await expect(wrapper).toHaveCount(0);
 });
 
+test('applies explicit polyfill options to adopted stylesheets in shadow root', async ({
+  page,
+}) => {
+  // Options given to `patchAndPolyfillConstructedStylesheets()` are forwarded
+  // to the polyfill run it sets up for each shadow root, and take precedence
+  // over the global options.
+  await page.addInitScript(() => {
+    window.ANCHOR_POSITIONING_POLYFILL_OPTIONS = {
+      positionAreaContainingBlock: true,
+    };
+  });
+  await page.goto('/shadow-dom.html');
+
+  await page.evaluate(async () => {
+    // Resolved by the Vite dev server at runtime; the indirection keeps `tsc`
+    // and the import linter from trying to resolve it statically.
+    const fnEntry = '/src/index-fn.ts';
+    const { patchAndPolyfillConstructedStylesheets } = await import(fnEntry);
+
+    patchAndPolyfillConstructedStylesheets({
+      positionAreaContainingBlock: false,
+    });
+
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(`
+      .anchor { anchor-name: --explicit-anchor; }
+      .target {
+        position: absolute;
+        position-anchor: --explicit-anchor;
+        position-area: bottom span-left;
+      }
+    `);
+
+    customElements.define(
+      'explicit-options',
+      class extends HTMLElement {
+        connectedCallback() {
+          this.attachShadow({ mode: 'open' });
+          this.shadowRoot!.adoptedStyleSheets = [sheet];
+          this.shadowRoot!.innerHTML = `
+            <div class="anchor">Anchor</div>
+            <div class="target">Target</div>`;
+        }
+      },
+    );
+
+    document.body.append(document.createElement('explicit-options'));
+  });
+
+  const target = page.locator('explicit-options .target');
+  const wrapper = page.locator('explicit-options POLYFILL-POSITION-AREA');
+
+  // Waiting on the attribute lets the queued polyfill run finish before the
+  // wrapper is asserted to be absent.
+  await expect(target).toHaveAttribute('data-anchor-position-area');
+  await expect(wrapper).toHaveCount(0);
+});
+
 test('positions every custom-element host sharing one constructed stylesheet', async ({
   page,
 }) => {

--- a/tests/e2e/shadow-dom.test.ts
+++ b/tests/e2e/shadow-dom.test.ts
@@ -97,6 +97,42 @@ test('applies polyfill for adopted stylesheets in shadow root', async ({
   expect(targetWrapperBox!.y).toBeCloseTo(anchorBox!.y + anchorBox!.height, 0);
 });
 
+test('applies global polyfill options to adopted stylesheets in shadow root', async ({
+  page,
+}) => {
+  // `patchAndPolyfillConstructedStylesheets()` runs the polyfill itself for
+  // each shadow root, so global options must carry over into those runs. With
+  // `positionAreaContainingBlock: false`, the `position-area` target must be
+  // positioned directly instead of wrapped in `<polyfill-position-area>`.
+  await page.addInitScript(() => {
+    window.ANCHOR_POSITIONING_POLYFILL_OPTIONS = {
+      positionAreaContainingBlock: false,
+    };
+  });
+  await page.goto('/shadow-dom.html');
+
+  await applyPolyfill(page);
+
+  const wrapper = page.locator('anchor-adopted-styles POLYFILL-POSITION-AREA');
+  const target = page.locator('anchor-adopted-styles .target');
+  const anchor = page.locator('anchor-adopted-styles .anchor');
+
+  // The unwrapped path marks the target itself instead of adding a wrapper.
+  await expect(target).toHaveAttribute('data-anchor-position-area');
+  await expect(wrapper).toHaveCount(0);
+
+  const anchorBox = await anchor.boundingBox();
+  const targetBox = await target.boundingBox();
+
+  // The target is still positioned by `position-area: bottom span-left`:
+  // right sides aligned, target top aligned with anchor bottom.
+  expect(targetBox!.x + targetBox!.width).toBeCloseTo(
+    anchorBox!.x + anchorBox!.width,
+    0,
+  );
+  expect(targetBox!.y).toBeCloseTo(anchorBox!.y + anchorBox!.height, 0);
+});
+
 test('positions every custom-element host sharing one constructed stylesheet', async ({
   page,
 }) => {

--- a/tests/e2e/shadow-dom.test.ts
+++ b/tests/e2e/shadow-dom.test.ts
@@ -115,22 +115,10 @@ test('applies global polyfill options to adopted stylesheets in shadow root', as
 
   const wrapper = page.locator('anchor-adopted-styles POLYFILL-POSITION-AREA');
   const target = page.locator('anchor-adopted-styles .target');
-  const anchor = page.locator('anchor-adopted-styles .anchor');
 
   // The unwrapped path marks the target itself instead of adding a wrapper.
   await expect(target).toHaveAttribute('data-anchor-position-area');
   await expect(wrapper).toHaveCount(0);
-
-  const anchorBox = await anchor.boundingBox();
-  const targetBox = await target.boundingBox();
-
-  // The target is still positioned by `position-area: bottom span-left`:
-  // right sides aligned, target top aligned with anchor bottom.
-  expect(targetBox!.x + targetBox!.width).toBeCloseTo(
-    anchorBox!.x + anchorBox!.width,
-    0,
-  );
-  expect(targetBox!.y).toBeCloseTo(anchorBox!.y + anchorBox!.height, 0);
 });
 
 test('positions every custom-element host sharing one constructed stylesheet', async ({


### PR DESCRIPTION
Fixes #442

The polyfill runs set up by `patchAndPolyfillConstructedStylesheets()` called `polyfill({ roots: [shadowRoot] })` with an explicit options object, so `polyfill()` never fell back to `window.ANCHOR_POSITIONING_POLYFILL_OPTIONS`. Global options such as `positionAreaContainingBlock: false` were silently ignored for shadow roots with adopted stylesheets — their `position-area` targets were still wrapped in `<polyfill-position-area>`.

`patchAndPolyfillConstructedStylesheets()` now accepts options and passes them down to `patchHostConnectedCallback()`, which forwards them to each `polyfill()` run, overriding `roots` with the shadow root being positioned. The options default to `window.ANCHOR_POSITIONING_POLYFILL_OPTIONS`, matching `polyfill()`, so the no-argument case picks up the global.

The new parameter is a backward-compatible addition to the public `/fn` export.

Includes e2e tests covering both paths: options set globally, and options passed explicitly (with a conflicting global, so the explicit argument has to win).